### PR TITLE
Improved: Editor should confirm user before leaving the page (ROL-2136)

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsps/editor/EntryEditor.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/EntryEditor.jsp
@@ -127,7 +127,6 @@
         }
         // Added event listener to confirm once the editor content is changed
         jQuery("#edit_content").one("change", function() {
-            console.log("this");
             jQuery(window).on("beforeunload", function(event) {
                 // Chrome requires returnValue to be set and original event is found as originalEvent
                 // see https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#Example

--- a/app/src/main/webapp/WEB-INF/jsps/editor/EntryEditor.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/EntryEditor.jsp
@@ -125,6 +125,17 @@
                 textAreaElement.focus();
             }
         }
+        // Added event listener to confirm once the editor content is changed
+        jQuery("#edit_content").one("change", function() {
+            console.log("this");
+            jQuery(window).on("beforeunload", function(event) {
+                // Chrome requires returnValue to be set and original event is found as originalEvent
+                // see https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#Example
+                if (event.originalEvent)
+                    event.originalEvent.returnValue = "Are you sure you want to leave?";
+                return "Are you sure you want to leave?";
+            });
+        });
     </script>
 </s:if>
 <s:else>
@@ -169,7 +180,7 @@
                 'edit_content', 'edit_summary'
             ];
 
-            xinha_plugins = xinha_plugins ? xinha_plugins :[];
+            xinha_plugins = xinha_plugins ? xinha_plugins :[ 'UnsavedChanges'];
             if(!Xinha.loadPlugins(xinha_plugins, xinha_init)) return;
 
             xinha_config = xinha_config ? xinha_config() : new Xinha.Config();


### PR DESCRIPTION
On the pages where editors are used, if the user has done some unsaved changes. Before closing window/tab it should confirm the user.
Done the following changes:
1. Included UnsavedChanges plugin for Xinha editor that implicitly handles it
2. Added custom code to add confirmation box for text area which adds an event handler to beforeunload event if the text area is changed.