### PR TITLE
War file location fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ ENV DATABASE_HOST ${DATABASE_HOST}
 # install Roller WAR as ROOT.war, create data dirs
 
 WORKDIR /usr/local/roller
-COPY --from=builder /project/app/target/roller.war /usr/local/tomcat/webapps/ROOT.war
+COPY --from=builder /tmp/roller/app/target/roller.war /usr/local/tomcat/webapps/ROOT.war
 RUN mkdir -p data/mediafiles data/searchindex
 
 # download PostgreSQL and MySQL drivers plus Mail and Activation JARs


### PR DESCRIPTION
Fix for getting the war file from the right location.
Steps for validation:

```
git clone https://github.com/apache/roller.git
cd roller
docker build -t rollerdocker .
```