### PR TITLE
Apache Lucene Renovation

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -49,7 +49,7 @@ limitations under the License.
         <guice.version>4.2.2</guice.version>
         <log4j.version>1.2.17</log4j.version>
         <log4j2.version>2.10.0</log4j2.version>
-        <lucene.version>4.10.4</lucene.version>
+        <lucene.version>8.1.1</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
         <maven-war.version>3.1.0</maven-war.version>
         <maven-surefire.version>2.17</maven-surefire.version>

--- a/app/src/main/java/org/apache/roller/weblogger/business/search/FieldConstants.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/search/FieldConstants.java
@@ -18,7 +18,6 @@
 /* Created on Jul 19, 2003 */
 package org.apache.roller.weblogger.business.search;
 
-import org.apache.lucene.util.Version;
 
 /**
  * Field constants for indexing blog entries and comments.
@@ -26,9 +25,6 @@ import org.apache.lucene.util.Version;
  * @author Mindaugas Idzelis (min@idzelis.com)
  */
 public final class FieldConstants {
-
-    // Set what version we are on
-    public static final Version LUCENE_VERSION = Version.LUCENE_44;
 
     public static final String ANCHOR = "anchor";
     public static final String UPDATED = "updated";

--- a/app/src/main/java/org/apache/roller/weblogger/business/search/IndexManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/search/IndexManagerImpl.java
@@ -150,11 +150,11 @@ public class IndexManagerImpl implements IndexManager {
 
             if (indexExists()) {
 
-                // test if the index is readable, if the version is outdated this might fail and we rebuild.
-                // TODO: we probably should just eagerly initialize the actual reader here, since we have it already
+                // test if the index is readable, if the version is outdated or it fails we rebuild.
                 try {
-                    DirectoryReader readerProbe = DirectoryReader.open(getFSDirectory(false));
-                    readerProbe.close();
+                    synchronized(this) {
+                        reader = DirectoryReader.open(getFSDirectory(false));
+                    }
                 } catch (IOException ex) {
                     mLogger.warn("Error opening search index, scheduling rebuild.", ex);
                     getFSDirectory(true);

--- a/app/src/main/java/org/apache/roller/weblogger/business/search/operations/IndexOperation.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/search/operations/IndexOperation.java
@@ -26,10 +26,12 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.lucene.analysis.miscellaneous.LimitTokenCountAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.util.BytesRef;
 import org.apache.roller.weblogger.business.search.FieldConstants;
 import org.apache.roller.weblogger.business.search.IndexManagerImpl;
 import org.apache.roller.weblogger.config.WebloggerConfig;
@@ -135,8 +137,8 @@ public abstract class IndexOperation implements Runnable {
 
         // keyword
         if (data.getPubTime() != null) {
-            doc.add(new StringField(FieldConstants.PUBLISHED, data.getPubTime()
-                    .toString(), Field.Store.YES));
+            // SearchOperation sorts results by date
+            doc.add(new SortedDocValuesField(FieldConstants.PUBLISHED, new BytesRef(data.getPubTime().toString())));
         }
 
         // index Category, needs to be in lower case as it is used in a term
@@ -173,8 +175,7 @@ public abstract class IndexOperation implements Runnable {
                     IndexManagerImpl.getAnalyzer(),
                     WebloggerConfig.getIntProperty("lucene.analyzer.maxTokenCount"));
 
-            IndexWriterConfig config = new IndexWriterConfig(
-                    FieldConstants.LUCENE_VERSION, analyzer);
+            IndexWriterConfig config = new IndexWriterConfig(analyzer);
 
             writer = new IndexWriter(manager.getIndexDirectory(), config);
 
@@ -201,6 +202,7 @@ public abstract class IndexOperation implements Runnable {
     /**
      * @see java.lang.Runnable#run()
      */
+    @Override
     public void run() {
         doRun();
     }

--- a/app/src/main/java/org/apache/roller/weblogger/business/search/operations/ReadFromIndexOperation.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/search/operations/ReadFromIndexOperation.java
@@ -32,13 +32,14 @@ public abstract class ReadFromIndexOperation extends IndexOperation {
     private static Log mLogger = LogFactory.getFactory().getInstance(
             ReadFromIndexOperation.class);
     
+    @Override
     public final void run() {
         try {
             manager.getReadWriteLock().readLock().lock();
             doRun();
 
         } catch (Exception e) {
-            mLogger.info("Error acquiring read lock on index", e);
+            mLogger.error("Error acquiring read lock on index", e);
         } finally {
             manager.getReadWriteLock().readLock().unlock();
         }


### PR DESCRIPTION
Hello!

updated apache lucene from 4.x to 8.1.x which required some code changes. Since lucene can only read indexes which are not older than 1-2 major versions (according to the exception i got), I added a simple check which causes a rebuild task if the index is unreadable. (first commit)

The second commit removes usages of the deprecated RAMDirectory. I decided to not migrate it to MMapDirectory because the code path isn't used anywhere (or tested). Furthermore: MMapDirectory extends FSDirectory (which is currently used), so it wouldn't use the old code in any case.

tests are green and i also deployed a build to my blog and tested the index rebuilding once.

- - - - 
the only change i am not sure about is: https://github.com/mbien/roller/commit/10370c129dd5d5cb906095fc23be41bb69014179#diff-afa10aab8f67b8be187418bf4264950dR140

Since the search results are sorted by pubdate, lucene 8 wants this field to be a DocValue of type SORTED instead of NONE and throws a IllegalStateException. So i changed it to SortedDocValuesField which made lucene happy. This field type does not have the stored yes/no property which the StringField had. Javadoc recommends to add another StoredField if storage is required - I just don't know if its needed for roller so I left it out.