### PR TITLE
fix global config jsp wrong tag

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsps/admin/GlobalConfig.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/admin/GlobalConfig.jsp
@@ -40,7 +40,7 @@
             <%-- special case for front page blog --%>
             <s:elseif test="#pd.name == 'site.frontpage.weblog.handle'">
                 <s:select name="%{#pd.name}" label="%{getText(#pd.key)}" value="%{properties[#pd.name].value}"
-                          list="weblogs" listKey="name" listValueKey="handle"/>
+                          list="weblogs" listKey="handle" listValueKey="name"/>
             </s:elseif>
 
             <%-- "string" type means use a simple textbox --%>


### PR DESCRIPTION
In the [WEB-INF/jsps/admin/GlobalConfig.jsp](https://github.com/apache/roller/blob/83d8f8bb4ca12e1a1000fcd8e3422de3f046fcb3/app/src/main/webapp/WEB-INF/jsps/admin/GlobalConfig.jsp#L43) file line 43:
`                          list="weblogs" listKey="name" listValueKey="handle"/>` is not correct, should be miss coding.