### PR TITLE
Fix global config jsp page bugs

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsps/admin/GlobalConfig.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/admin/GlobalConfig.jsp
@@ -59,12 +59,10 @@
             <s:elseif test="#pd.type == 'boolean'">
 
                 <s:if test="properties[#pd.name].value == 'true'">
-                    <s:checkbox name="%{#pd.name}" label="%{getText(#pd.key)}"
-                                fieldValue="true" checked="true" onchange="formChanged()"/>
+                    <s:checkbox name="%{#pd.name}" label="%{getText(#pd.key)}" checked="true" onchange="formChanged()"/>
                 </s:if>
                 <s:if test="properties[#pd.name].value != 'true'">
-                    <s:checkbox name="%{#pd.name}" label="%{getText(#pd.key)}"
-                                fieldValue="false" onchange="formChanged()"/>
+                    <s:checkbox name="%{#pd.name}" label="%{getText(#pd.key)}" onchange="formChanged()"/>
                 </s:if>
 
             </s:elseif>

--- a/app/src/main/webapp/WEB-INF/jsps/admin/GlobalConfig.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/admin/GlobalConfig.jsp
@@ -40,7 +40,7 @@
             <%-- special case for front page blog --%>
             <s:elseif test="#pd.name == 'site.frontpage.weblog.handle'">
                 <s:select name="%{#pd.name}" label="%{getText(#pd.key)}" value="%{properties[#pd.name].value}"
-                          list="weblogs" listKey="name" listValueKey="handle"/>
+                          list="weblogs" listKey="handle" listValueKey="name"/>
             </s:elseif>
 
             <%-- "string" type means use a simple textbox --%>

--- a/app/src/main/webapp/WEB-INF/jsps/admin/GlobalConfig.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/admin/GlobalConfig.jsp
@@ -59,10 +59,12 @@
             <s:elseif test="#pd.type == 'boolean'">
 
                 <s:if test="properties[#pd.name].value == 'true'">
-                    <s:checkbox name="%{#pd.name}" label="%{getText(#pd.key)}" checked="true" onchange="formChanged()"/>
+                    <s:checkbox name="%{#pd.name}" label="%{getText(#pd.key)}"
+                                fieldValue="true" checked="true" onchange="formChanged()"/>
                 </s:if>
                 <s:if test="properties[#pd.name].value != 'true'">
-                    <s:checkbox name="%{#pd.name}" label="%{getText(#pd.key)}" onchange="formChanged()"/>
+                    <s:checkbox name="%{#pd.name}" label="%{getText(#pd.key)}"
+                                fieldValue="false" onchange="formChanged()"/>
                 </s:if>
 
             </s:elseif>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@ limitations under the License.
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.0</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>11</source>
+                        <target>11</target>
                         <fork>true</fork>
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@ limitations under the License.
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.0</version>
                     <configuration>
-                        <source>11</source>
-                        <target>11</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                         <fork>true</fork>
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>


### PR DESCRIPTION
1. Wrong tags in `site.frontpage.weblog.handle` select `listKey` and `listValueKey`, this will cause the database store wrong value;
2. For `#pd.type` is `boolean` used wrong `fieldValue` values, these tags will cause the `boolean` type value can not set to `true` values when you set any value before.