### PR TITLE
Improved: Replaced pom.basedir deprecated property with project.basedir. (ROL-2158)

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -575,7 +575,7 @@ limitations under the License.
                             <port>4224</port>
                             <sources>
                                 <script>
-                                    <sourceFile>${pom.basedir}/target/dbscripts/derby/createdb.sql</sourceFile>
+                                    <sourceFile>${project.basedir}/target/dbscripts/derby/createdb.sql</sourceFile>
                                 </script>
                             </sources>
                         </configuration>


### PR DESCRIPTION
NOTE:
Deprecated features are those that have been retained temporarily for backward compatibility, but which will eventually be removed. In effect, deprecation announces a grace period to allow the smooth transition from the old features to the new ones. In that period, no use of the deprecated features should be added, and all existing uses should be gradually removed.