### PR TITLE
made it easier to run roller on latest JVMs (tested with JDK 13).

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -40,21 +40,22 @@ limitations under the License.
         <jstl.version>1.2</jstl.version>
 
         <angular.version>1.7.8</angular.version>
-        <ant.version>1.10.5</ant.version>
+        <ant.version>1.10.7</ant.version>
+        <asm.version>7.2</asm.version>
         <commons-validator.version>1.6</commons-validator.version>
-        <commons-beanutils.version>1.9.3</commons-beanutils.version>
+        <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>
-        <commons-codec.version>1.12</commons-codec.version>
-        <eclipse-link.version>2.7.4</eclipse-link.version>
+        <commons-codec.version>1.13</commons-codec.version>
+        <eclipse-link.version>2.7.5</eclipse-link.version>
         <guice.version>4.2.2</guice.version>
         <log4j.version>1.2.17</log4j.version>
         <log4j2.version>2.10.0</log4j2.version>
-        <lucene.version>8.1.1</lucene.version>
+        <lucene.version>8.3.0</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
-        <maven-war.version>3.1.0</maven-war.version>
+        <maven-war.version>3.2.3</maven-war.version>
         <maven-surefire.version>2.17</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
-        <rome.version>1.12.0</rome.version>
+        <rome.version>1.12.2</rome.version>
         <slf4j.version>1.7.26</slf4j.version>
         <spring.version>4.1.4.RELEASE</spring.version>
         <spring.security.version>3.2.5.RELEASE</spring.security.version>
@@ -108,6 +109,13 @@ limitations under the License.
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.3.1</version>
+            <exclusions>
+                <exclusion>
+                    <!--api is already in the javax.activation artifact-->
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Eclipselink JPA is the default JPA implementation used by
@@ -184,19 +192,19 @@ limitations under the License.
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>7.0</version>
+            <version>${asm.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>
-            <version>7.0</version>
+            <version>${asm.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-tree</artifactId>
-            <version>7.0</version>
+            <version>${asm.version}</version>
         </dependency>
         
         <dependency>
@@ -383,6 +391,12 @@ limitations under the License.
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-openid</artifactId>
             <version>${spring.security.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.inject</groupId>
+                    <artifactId>guice</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -416,6 +430,7 @@ limitations under the License.
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>${guice.version}</version>
+            <classifier>no_aop</classifier>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <source>11</source>
                         <target>11</target>
@@ -91,6 +91,14 @@ limitations under the License.
                         <monitorPort>11527</monitorPort>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.7</version>
+                    <configuration>
+                        <rulesUri>file:version-rules.xml</rulesUri>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -100,7 +108,7 @@ limitations under the License.
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.1.0</version>
+                <version>5.5.2</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/version-rules.xml
+++ b/version-rules.xml
@@ -1,0 +1,16 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+    <ignoreVersions>
+        <!--only release builds-->
+        <ignoreVersion type="regex">.*(alpha|ALPHA|beta|BETA|b|rc|RC|M).*</ignoreVersion>
+        
+        <!--ignore some specific version strings which don't follow the common version format-->
+        <ignoreVersion type="exact">20020829</ignoreVersion>
+        <ignoreVersion type="exact">20040616</ignoreVersion>
+        <ignoreVersion type="exact">20040102.233541</ignoreVersion>
+        <ignoreVersion type="exact">20031027.000000</ignoreVersion>
+        <ignoreVersion type="exact">20030418.083655</ignoreVersion>
+    </ignoreVersions>
+
+</ruleset>


### PR DESCRIPTION
- use "no_aop" version of guice which doesn't bundle its own ASM version
- bumped ASM dependency to 7.2 for Java 13 compatibility

fixed some jetty warnings by not adding the javax.activation api classes twice.
minor maven dependency updates.
added version checker maven plugin, can be run with: mvn versions:display-dependency-updates.