### PR TITLE
[ROL-2160] Fix for Server admin page failes to render bug

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsps/admin/GlobalConfig.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/admin/GlobalConfig.jsp
@@ -40,7 +40,7 @@
             <%-- special case for front page blog --%>
             <s:elseif test="#pd.name == 'site.frontpage.weblog.handle'">
                 <s:select name="%{#pd.name}" label="%{getText(#pd.key)}" value="%{properties[#pd.name].value}"
-                          list="weblogs" listKey="handle" listValueKey="name"/>
+                          list="weblogs" listKey="handle" listValueKey="handle"/>
             </s:elseif>
 
             <%-- "string" type means use a simple textbox --%>


### PR DESCRIPTION
This PR works-around an apparent Struts but by showing weblog handle instead of name in front-page select. More details here: https://issues.apache.org/jira/browse/ROL-2160

