### PR TITLE
fixed remove template action. Registration was missing in struts.xml.

### DIFF
--- a/app/src/main/resources/struts.xml
+++ b/app/src/main/resources/struts.xml
@@ -568,6 +568,13 @@
             <result name="input" type="tiles">.TemplateEdit</result>
             <allowed-methods>execute,save</allowed-methods>
         </action>
+        
+        <action name="templateRemove"
+                class="org.apache.roller.weblogger.ui.struts2.editor.TemplateRemove">
+            <result name="confirm" type="tiles">.TemplateRemove</result>
+            <result name="success" type="chain">templates</result>
+            <allowed-methods>execute,remove</allowed-methods>
+        </action>
 
         <action name="members"
                 class="org.apache.roller.weblogger.ui.struts2.editor.Members">


### PR DESCRIPTION
Hello Dave,
It appears that a past commit intended to remove the templatesRemove action but removed templateRemove too (https://github.com/apache/roller/commit/44b008d5d761e08eead9a643821b2d66684c7382#diff-207d6f47f5499d9694104c3640c3b379 ). 

So i added it again and the action is working again. Since the confirm dialog seems to be client side now I left the cancel/redirect lines out.