### PR TITLE
search index compatibility and other minor changes

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -39,22 +39,22 @@ limitations under the License.
         <java-mail.version>1.4.7</java-mail.version>
         <jstl.version>1.2</jstl.version>
         <angular.version>1.7.8</angular.version>
-        <ant.version>1.10.7</ant.version>
-        <asm.version>7.2</asm.version>
+        <ant.version>1.10.8</ant.version>
+        <asm.version>8.0.1</asm.version>
         <commons-validator.version>1.6</commons-validator.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>
-        <commons-codec.version>1.13</commons-codec.version>
-        <eclipse-link.version>2.7.5</eclipse-link.version>
-        <guice.version>4.2.2</guice.version>
+        <commons-codec.version>1.14</commons-codec.version>
+        <eclipse-link.version>2.7.7</eclipse-link.version>
+        <guice.version>4.2.3</guice.version>
         <log4j.version>1.2.17</log4j.version>
         <log4j2.version>2.10.0</log4j2.version>
-        <lucene.version>8.3.0</lucene.version>
+        <lucene.version>8.5.1</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
         <maven-war.version>3.2.3</maven-war.version>
         <maven-surefire.version>2.17</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
-        <rome.version>1.12.2</rome.version>
+        <rome.version>1.13.1</rome.version>
         <slf4j.version>1.7.26</slf4j.version>
         <spring.version>4.1.4.RELEASE</spring.version>
         <spring.security.version>3.2.5.RELEASE</spring.security.version>
@@ -264,9 +264,17 @@ limitations under the License.
             <artifactId>jquery-validation</artifactId>
             <version>1.19.0</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
+            <scope>compile</scope>
+            <version>${lucene.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-backward-codecs</artifactId>
             <scope>compile</scope>
             <version>${lucene.version}</version>
         </dependency>

--- a/app/src/main/java/org/apache/roller/weblogger/business/search/IndexManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/search/IndexManagerImpl.java
@@ -61,30 +61,22 @@ import org.apache.roller.weblogger.config.WebloggerConfig;
  */
 @com.google.inject.Singleton
 public class IndexManagerImpl implements IndexManager {
-    // ~ Static fields/initializers
-    // =============================================
 
     private IndexReader reader;
     private final Weblogger roller;
 
-    static Log mLogger = LogFactory.getFactory().getInstance(
-            IndexManagerImpl.class);
-
-    // ~ Instance fields
-    // ========================================================
+    private final static Log mLogger = LogFactory.getFactory().getInstance(IndexManagerImpl.class);
 
     private boolean searchEnabled = true;
 
-    private final File indexConsistencyMarker;
+    private final String indexDir;
 
-    private String indexDir = null;
+    private final File indexConsistencyMarker;
 
     private boolean inconsistentAtStartup = false;
 
     private final ReadWriteLock rwl = new ReentrantReadWriteLock();
 
-    // ~ Constructors
-    // ===========================================================
 
     /**
      * Creates a new lucene index manager. This should only be created once.
@@ -178,48 +170,34 @@ public class IndexManagerImpl implements IndexManager {
 
     }
 
-    // ~ Methods
-    // ================================================================
-
     @Override
     public void rebuildWebsiteIndex() throws WebloggerException {
-        scheduleIndexOperation(new RebuildWebsiteIndexOperation(roller, this,
-                null));
+        scheduleIndexOperation(new RebuildWebsiteIndexOperation(roller, this, null));
     }
 
     @Override
     public void rebuildWebsiteIndex(Weblog website) throws WebloggerException {
-        scheduleIndexOperation(new RebuildWebsiteIndexOperation(roller, this,
-                website));
+        scheduleIndexOperation(new RebuildWebsiteIndexOperation(roller, this, website));
     }
 
     @Override
     public void removeWebsiteIndex(Weblog website) throws WebloggerException {
-        scheduleIndexOperation(new RemoveWebsiteIndexOperation(roller, this,
-                website));
+        scheduleIndexOperation(new RemoveWebsiteIndexOperation(roller, this, website));
     }
 
     @Override
-    public void addEntryIndexOperation(WeblogEntry entry)
-            throws WebloggerException {
-        AddEntryOperation addEntry = new AddEntryOperation(roller, this, entry);
-        scheduleIndexOperation(addEntry);
+    public void addEntryIndexOperation(WeblogEntry entry) throws WebloggerException {
+        scheduleIndexOperation(new AddEntryOperation(roller, this, entry));
     }
 
     @Override
-    public void addEntryReIndexOperation(WeblogEntry entry)
-            throws WebloggerException {
-        ReIndexEntryOperation reindex = new ReIndexEntryOperation(roller, this,
-                entry);
-        scheduleIndexOperation(reindex);
+    public void addEntryReIndexOperation(WeblogEntry entry) throws WebloggerException {
+        scheduleIndexOperation(new ReIndexEntryOperation(roller, this, entry));
     }
 
     @Override
-    public void removeEntryIndexOperation(WeblogEntry entry)
-            throws WebloggerException {
-        RemoveEntryOperation removeOp = new RemoveEntryOperation(roller, this,
-                entry);
-        executeIndexOperationNow(removeOp);
+    public void removeEntryIndexOperation(WeblogEntry entry) throws WebloggerException {
+        executeIndexOperationNow(new RemoveEntryOperation(roller, this, entry));
     }
 
     public ReadWriteLock getReadWriteLock() {

--- a/app/src/main/java/org/apache/roller/weblogger/util/cache/ExpiringLRUCacheImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/util/cache/ExpiringLRUCacheImpl.java
@@ -75,11 +75,7 @@ public class ExpiringLRUCacheImpl extends LRUCacheImpl {
     public synchronized Object get(String key) {
         
         Object value = null;
-        ExpiringCacheEntry entry = null;
-        
-        synchronized(this) {
-            entry = (ExpiringCacheEntry) super.get(key);
-        }
+        ExpiringCacheEntry entry = (ExpiringCacheEntry) super.get(key);
         
         if (entry != null) {
             

--- a/app/src/main/java/org/apache/roller/weblogger/util/cache/LRUCacheImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/util/cache/LRUCacheImpl.java
@@ -18,7 +18,6 @@
 
 package org.apache.roller.weblogger.util.cache;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -31,8 +30,8 @@ import org.apache.roller.util.RollerConstants;
  */
 public class LRUCacheImpl implements Cache {
     
-    private String id = null;
-    private Map cache = null;
+    private final String id;
+    private final Map cache;
     
     // for metrics
     protected double hits = 0;
@@ -44,18 +43,18 @@ public class LRUCacheImpl implements Cache {
     
     protected LRUCacheImpl(String id) {
         
-        this.id = id;
-        this.cache = Collections.synchronizedMap(new LRULinkedHashMap(100));
+        this(id, 100);
     }
     
     
     protected LRUCacheImpl(String id, int maxsize) {
         
         this.id = id;
-        this.cache = Collections.synchronizedMap(new LRULinkedHashMap(maxsize));
+        this.cache = new LRULinkedHashMap(maxsize);
     }
     
     
+    @Override
     public String getId() {
         return this.id;
     }
@@ -64,6 +63,7 @@ public class LRUCacheImpl implements Cache {
     /**
      * Store an entry in the cache.
      */
+    @Override
     public synchronized void put(String key, Object value) {
         
         this.cache.put(key, value);
@@ -74,6 +74,7 @@ public class LRUCacheImpl implements Cache {
     /**
      * Retrieve an entry from the cache.
      */
+    @Override
     public synchronized Object get(String key) {
         
         Object obj = this.cache.get(key);
@@ -89,6 +90,7 @@ public class LRUCacheImpl implements Cache {
     }
     
     
+    @Override
     public synchronized void remove(String key) {
         
         this.cache.remove(key);
@@ -96,6 +98,7 @@ public class LRUCacheImpl implements Cache {
     }
     
     
+    @Override
     public synchronized void clear() {
         
         this.cache.clear();
@@ -109,6 +112,7 @@ public class LRUCacheImpl implements Cache {
     }
     
     
+    @Override
     public Map<String, Object> getStats() {
         
         Map<String, Object> stats = new HashMap<String, Object>();

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ limitations under the License.
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.5.2</version>
+                <version>5.6.2</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
I set this pull request against 6.0.x since master had bugs and was lacking behind last time I tried (see https://github.com/apache/roller/pull/58#issuecomment-616370669).

contents:
- better lucene search index compatibility. Point release updates won't trigger index rebuilds
- updated project dependencies to latest releases (skipped spring and webjars)
- removed double synchronization in cache
- tested on 11, 14 and 15b26
