### PR TITLE
fixBug PropertyNotFoundException

### DIFF
--- a/app/src/main/resources/org/apache/roller/weblogger/pojos/WeblogEntryComment.orm.xml
+++ b/app/src/main/resources/org/apache/roller/weblogger/pojos/WeblogEntryComment.orm.xml
@@ -106,6 +106,7 @@
             <transient name="spam"/>
             <transient name="pending"/>
             <transient name="approved"/>
+            <transient name="emptyString"/>
         </attributes>
     </entity>
 </entity-mappings>


### PR DESCRIPTION
During deploy on clean Wildfly 19 installation there were the foollowing exception:
org.hibernate.PropertyNotFoundException: Could not locate setter method for property [org.apache.roller.weblogger.pojos.WeblogEntryComment#emptyString]
Adding missing <transient> element for emptyString property in orm descriptor fixes the problem.