### PR TITLE
Fix for dusty integration tests

### DIFF
--- a/it-selenium/pom.xml
+++ b/it-selenium/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>3.4.0</version>
+            <version>3.141.59</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-firefox-driver</artifactId>
-            <version>3.4.0</version>
+            <version>3.141.59</version>
         </dependency>
 
         <!-- Will bring in once we configure a Chrome option -->
@@ -73,6 +73,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
 
@@ -88,11 +89,6 @@
             <type>war</type>
         </dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-
     </dependencies>
 
     <build>
@@ -102,7 +98,7 @@
             -->
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20</version>
+                <version>3.0.0-M5</version>
                 <executions>
                     <execution>
                         <goals>
@@ -111,6 +107,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.3.1</version>
+                    </dependency>
+                </dependencies>                    
             </plugin>
 
             <!-- Activates the Derby database during the integration test phase -->
@@ -189,6 +192,12 @@
                     </execution>
                 </executions>
                 <dependencies>
+                            
+                    <dependency>
+                        <groupId>commons-dbcp</groupId>
+                        <artifactId>commons-dbcp</artifactId>
+                        <version>1.4</version>
+                    </dependency>
 
                     <dependency>
                         <groupId>org.apache.derby</groupId>

--- a/it-selenium/src/test/java/org/apache/roller/selenium/AbstractRollerPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/AbstractRollerPage.java
@@ -56,7 +56,7 @@ public abstract class AbstractRollerPage {
     */
     protected void verifyIdOnPage(String idOnPage) {
         try {
-            WebElement div = driver.findElement(By.id(idOnPage));
+            driver.findElement(By.id(idOnPage));
         } catch (NoSuchElementException e) {
             throw new IllegalStateException("HTML ID: " + idOnPage + " not found.");
         }
@@ -70,14 +70,14 @@ public abstract class AbstractRollerPage {
 
     protected void clickById(String buttonId) {
         WebElement element = driver.findElement(By.id(buttonId));
+        System.out.println("clicking element " + element.getTagName() + " id:" + element.getAttribute("id"));
         element.click();
-        System.out.println("Element " + element.getTagName() + " id:" + element.getAttribute("id") + " clicked");
     }
 
     protected void clickByLinkText(String buttonText) {
         WebElement element = driver.findElement(By.linkText(buttonText));
+        System.out.println("clicking element " + element.getTagName() + " id:" + element.getAttribute("id"));
         element.click();
-        System.out.println("Element " + element.getTagName() + " id:" + element.getAttribute("id") + " clicked");
     }
 
     protected String getTextByCSS(String cssSelector) {

--- a/it-selenium/src/test/java/org/apache/roller/selenium/InitialLoginTestIT.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/InitialLoginTestIT.java
@@ -17,14 +17,10 @@
  */
 package org.apache.roller.selenium;
 
-import java.util.regex.Pattern;
 import java.util.concurrent.TimeUnit;
 import org.junit.*;
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
 import org.openqa.selenium.*;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.support.ui.Select;
 import org.apache.roller.selenium.core.CreateWeblogPage;
 import org.apache.roller.selenium.core.LoginPage;
 import org.apache.roller.selenium.core.MainMenuPage;
@@ -35,7 +31,10 @@ import org.apache.roller.selenium.editor.EntryAddPage;
 import org.apache.roller.selenium.editor.EntryEditPage;
 import org.apache.roller.selenium.view.BlogHomePage;
 import org.apache.roller.selenium.view.SingleBlogEntryPage;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
+
+import static org.junit.Assert.*;
 
 public class InitialLoginTestIT {
     private WebDriver driver;
@@ -45,11 +44,19 @@ public class InitialLoginTestIT {
 
     @Before
     public void setUp() throws Exception {
+
         FirefoxProfile profile = new FirefoxProfile();
         profile.setPreference("intl.accept_languages", "en_US");
-        driver = new FirefoxDriver(profile);
+        
+        FirefoxOptions options = new FirefoxOptions();
+        options.setProfile(profile);
+        
+        driver = new FirefoxDriver(options);
+        driver.manage().timeouts().implicitlyWait(5, TimeUnit.SECONDS)
+                                  .pageLoadTimeout(5, TimeUnit.SECONDS)
+                                  .setScriptTimeout(5, TimeUnit.SECONDS);
+        
         baseUrl = "http://localhost:8080/roller/";
-        driver.manage().timeouts().implicitlyWait(30, TimeUnit.SECONDS);
     }
 
     @Test
@@ -59,8 +66,10 @@ public class InitialLoginTestIT {
         SetupPage sp = new SetupPage(driver);
         RegisterPage rp = sp.createNewUser();
         WelcomePage wp = rp.submitUserRegistration("bsmith", "Bob Smith", "bsmith@email.com", "roller123");
+        
         LoginPage lp = wp.doRollerLogin();
         MainMenuPage mmp = lp.loginToRoller("bsmith", "roller123");
+        
         CreateWeblogPage cwp = mmp.createWeblog();
         cwp.createWeblog("Bob's Blog", "bobsblog", "bsmith@email.com");
 
@@ -77,6 +86,7 @@ public class InitialLoginTestIT {
         eap.setTitle(blogEntryTitle);
         eap.setText(blogEntryContent);
         EntryEditPage eep = eap.postBlogEntry();
+        
         SingleBlogEntryPage sbep = eep.viewBlogEntry();
         System.out.println("title/text: " + sbep.getBlogTitle() + " / " + sbep.getBlogText());
         assertEquals(blogEntryTitle, sbep.getBlogTitle());

--- a/it-selenium/src/test/java/org/apache/roller/selenium/core/LoginPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/core/LoginPage.java
@@ -20,8 +20,6 @@ package org.apache.roller.selenium.core;
 import org.apache.roller.selenium.AbstractRollerPage;
 import org.openqa.selenium.WebDriver;
 
-import java.lang.String;
-
 /**
  * represents core/login.jsp
  * Page Object that handles user login to Roller

--- a/it-selenium/src/test/java/org/apache/roller/selenium/core/MainMenuPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/core/MainMenuPage.java
@@ -21,7 +21,6 @@ import org.apache.roller.selenium.AbstractRollerPage;
 import org.apache.roller.selenium.editor.EntryAddPage;
 import org.openqa.selenium.WebDriver;
 
-import java.lang.String;
 
 /**
  * represents core/MainMenu.jsp
@@ -32,7 +31,7 @@ public class MainMenuPage extends AbstractRollerPage {
 
     public MainMenuPage(WebDriver driver) {
         this.driver = driver;
-        pageTitle = "Front Page: Main Menu";
+        pageTitle = "Front Page: Your Weblogs";
     }
 
     public CreateWeblogPage createWeblog() {

--- a/it-selenium/src/test/java/org/apache/roller/selenium/core/RegisterPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/core/RegisterPage.java
@@ -23,7 +23,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import java.lang.String;
 
 /**
  * represents core/Register.jsp

--- a/it-selenium/src/test/resources/roller-jettyrun.properties
+++ b/it-selenium/src/test/resources/roller-jettyrun.properties
@@ -23,7 +23,7 @@ hibernate.transaction.factory_class=org.hibernate.transaction.JDBCTransactionFac
 passwds.encryption.enabled=false
 
 # use src copy of themes for read-only access
-themes.dir=target/roller-selenium-tests-6.0.0/themes
+themes.dir=target/war/work/org.apache.roller/roller-webapp/themes
 
 # put work in work dir
 search.index.dir          =target/work/search-index


### PR DESCRIPTION
integration tests should be working again.

commit msg:
 - the pom was broken possibly from a merge conflict from some time ago
 - fixed some paths and dependencies
 - adapted for firefox driver api changes
 - some tests needed minor updates due to the new bootstrap UI
 - some tests threw StaleElementReference exceptions when they tried to access elements after
   clicking a hyperlink which reloaded the page; fixed that too

tested with:
 cd it-selenium
 mvn clean integration-test -Dwebdriver.gecko.driver=/path/to/geckodriver

used:
 geckodriver v0.26.0 on 64bit linux, latest firefox, jdk 14 and everything worked fine.

note:
 do a mvn install of the roller root project first. Doing this for ./app is not sufficient
 since the tests look for the project pom/war in local repo, not roller.war.
note2:
 the test will display a few meters of jetty "class scanned from multiple locations" warnings
 since the classpath is apperently set to target/ and the local copy in the maven repo.
 Isn't convention over configuration great? I did not further attempt to fix this after trying
 out some different dependency scopes without any effect.