### PR TITLE
Fix 'mvn jetty:run' and the it-selenium tests.

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -55,7 +55,6 @@ limitations under the License.
         <maven-antrun.version>1.0b3</maven-antrun.version>
         <rome.version>1.13.1</rome.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <spring.version>5.2.7.RELEASE</spring.version>
         <spring.security.version>5.3.3.RELEASE</spring.security.version>
         <struts.version>2.5.22</struts.version>
         <velocity.version>2.2</velocity.version>
@@ -87,6 +86,7 @@ limitations under the License.
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
             <version>${jstl.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -105,7 +105,7 @@ limitations under the License.
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
+            <version>${jaxb.version}</version>
             <exclusions>
                 <exclusion>
                     <!--api is already in the javax.activation artifact-->
@@ -492,7 +492,6 @@ limitations under the License.
             </exclusions>
         </dependency>
 
-
         <!-- Other deps include Guice and ROME -->
 
         <dependency>
@@ -598,7 +597,7 @@ limitations under the License.
                     <webApp>
                         <contextPath>/roller</contextPath>
                     </webApp>
-                    <jettyXml>src/test/resources/jetty.xml</jettyXml>
+                    <jettyXmls>src/test/resources/jetty.xml</jettyXmls>
                     <systemProperties>
                         <systemProperty>
                             <name>roller.custom.config</name>

--- a/it-selenium/pom.xml
+++ b/it-selenium/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>3.4.0</version>
+            <version>3.14.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
@@ -60,7 +60,34 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-firefox-driver</artifactId>
-            <version>3.4.0</version>
+            <version>3.14.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xalan</groupId>
+                    <artifactId>xalan</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!--api is already in the javax.activation artifact-->
+                    <groupId>javax.activation</groupId>
+                    <artifactId>javax.activation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Will bring in once we configure a Chrome option -->
@@ -74,6 +101,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
+            <version>4.12</version>
         </dependency>
 
         <!--
@@ -88,21 +116,15 @@
             <type>war</type>
         </dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-
     </dependencies>
 
     <build>
         <plugins>
 
-            <!-- Activates integration tests (by default, classes under tests that end with "IT")
-            -->
+            <!-- Activates integration tests (by default, classes under tests that end with "IT") -->
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.22.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -132,7 +154,7 @@
                             <port>4224</port>
                             <sources>
                                 <script>
-                                    <sourceFile>target/roller-selenium-tests-${project.version}/WEB-INF/classes/dbscripts/derby/createdb.sql</sourceFile>
+                                    <sourceFile>${project.basedir}/target/roller-selenium-tests-${project.version}/WEB-INF/classes/dbscripts/derby/createdb.sql</sourceFile>
                                 </script>
                             </sources>
                         </configuration>
@@ -160,7 +182,7 @@
                         <contextPath>/roller</contextPath>
                     </webApp>
                     <webAppSourceDirectory>target/roller-selenium-tests-${project.version}</webAppSourceDirectory>
-                    <jettyXml>../app/src/test/resources/jetty.xml</jettyXml>
+                    <jettyXmls>${project.parent.basedir}/app/src/test/resources/jetty.xml</jettyXmls>
                     <systemProperties>
                         <systemProperty>
                             <name>roller.custom.config</name>
@@ -176,8 +198,6 @@
                             <goal>start</goal>
                         </goals>
                         <configuration>
-                            <scanIntervalSeconds>0</scanIntervalSeconds>
-                            <!-- <daemon>true</daemon> -->
                         </configuration>
                     </execution>
                     <execution>
@@ -203,9 +223,29 @@
                     </dependency>
 
                     <dependency>
+                        <groupId>commons-dbcp</groupId>
+                        <artifactId>commons-dbcp</artifactId>
+                        <version>1.4</version>
+                        <scope>runtime</scope>
+                    </dependency>
+
+                    <dependency>
                         <groupId>javax.mail</groupId>
                         <artifactId>mail</artifactId>
                         <version>1.4.7</version>
+                    </dependency>
+
+                    <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>${jaxb.version}</version>
+                        <exclusions>
+                            <exclusion>
+                                <!--api is already in the javax.activation artifact-->
+                                <groupId>javax.activation</groupId>
+                                <artifactId>javax.activation-api</artifactId>
+                            </exclusion>
+                        </exclusions>
                     </dependency>
 
                 </dependencies>

--- a/it-selenium/src/test/java/org/apache/roller/selenium/AbstractRollerPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/AbstractRollerPage.java
@@ -70,14 +70,14 @@ public abstract class AbstractRollerPage {
 
     protected void clickById(String buttonId) {
         WebElement element = driver.findElement(By.id(buttonId));
+        System.out.println("Clinking Element " + element.getTagName() + " id:" + element.getAttribute("id"));
         element.click();
-        System.out.println("Element " + element.getTagName() + " id:" + element.getAttribute("id") + " clicked");
     }
 
     protected void clickByLinkText(String buttonText) {
         WebElement element = driver.findElement(By.linkText(buttonText));
+        System.out.println("Clicking Element " + element.getTagName() + " id:" + element.getAttribute("id"));
         element.click();
-        System.out.println("Element " + element.getTagName() + " id:" + element.getAttribute("id") + " clicked");
     }
 
     protected String getTextByCSS(String cssSelector) {

--- a/it-selenium/src/test/java/org/apache/roller/selenium/InitialLoginTestIT.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/InitialLoginTestIT.java
@@ -17,14 +17,7 @@
  */
 package org.apache.roller.selenium;
 
-import java.util.regex.Pattern;
 import java.util.concurrent.TimeUnit;
-import org.junit.*;
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
-import org.openqa.selenium.*;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.support.ui.Select;
 import org.apache.roller.selenium.core.CreateWeblogPage;
 import org.apache.roller.selenium.core.LoginPage;
 import org.apache.roller.selenium.core.MainMenuPage;
@@ -35,7 +28,19 @@ import org.apache.roller.selenium.editor.EntryAddPage;
 import org.apache.roller.selenium.editor.EntryEditPage;
 import org.apache.roller.selenium.view.BlogHomePage;
 import org.apache.roller.selenium.view.SingleBlogEntryPage;
-import org.openqa.selenium.firefox.FirefoxProfile;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Alert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoAlertPresentException;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class InitialLoginTestIT {
     private WebDriver driver;
@@ -45,10 +50,11 @@ public class InitialLoginTestIT {
 
     @Before
     public void setUp() throws Exception {
-        FirefoxProfile profile = new FirefoxProfile();
-        profile.setPreference("intl.accept_languages", "en_US");
-        driver = new FirefoxDriver(profile);
         baseUrl = "http://localhost:8080/roller/";
+        FirefoxOptions options = new FirefoxOptions();
+        options.addPreference("intl.accept_languages", "en_US");
+        options.addPreference("browser.startup.homepage", baseUrl);
+        driver = new FirefoxDriver(options);
         driver.manage().timeouts().implicitlyWait(30, TimeUnit.SECONDS);
     }
 

--- a/it-selenium/src/test/java/org/apache/roller/selenium/core/CreateWeblogPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/core/CreateWeblogPage.java
@@ -20,8 +20,6 @@ package org.apache.roller.selenium.core;
 import org.apache.roller.selenium.AbstractRollerPage;
 import org.openqa.selenium.WebDriver;
 
-import java.lang.String;
-
 /**
  * represents core/CreateWeblog.jsp
  */

--- a/it-selenium/src/test/java/org/apache/roller/selenium/core/LoginPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/core/LoginPage.java
@@ -20,8 +20,6 @@ package org.apache.roller.selenium.core;
 import org.apache.roller.selenium.AbstractRollerPage;
 import org.openqa.selenium.WebDriver;
 
-import java.lang.String;
-
 /**
  * represents core/login.jsp
  * Page Object that handles user login to Roller

--- a/it-selenium/src/test/java/org/apache/roller/selenium/core/MainMenuPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/core/MainMenuPage.java
@@ -21,8 +21,6 @@ import org.apache.roller.selenium.AbstractRollerPage;
 import org.apache.roller.selenium.editor.EntryAddPage;
 import org.openqa.selenium.WebDriver;
 
-import java.lang.String;
-
 /**
  * represents core/MainMenu.jsp
  * Post-login page object to create, choose, configure blogs.
@@ -32,7 +30,7 @@ public class MainMenuPage extends AbstractRollerPage {
 
     public MainMenuPage(WebDriver driver) {
         this.driver = driver;
-        pageTitle = "Front Page: Main Menu";
+        pageTitle = "Front Page: Your Weblogs";
     }
 
     public CreateWeblogPage createWeblog() {

--- a/it-selenium/src/test/java/org/apache/roller/selenium/core/RegisterPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/core/RegisterPage.java
@@ -23,8 +23,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import java.lang.String;
-
 /**
  * represents core/Register.jsp
  * index page that does step #1 of setup.jsp, the adding of a new user

--- a/it-selenium/src/test/java/org/apache/roller/selenium/core/SetupPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/core/SetupPage.java
@@ -19,12 +19,7 @@ package org.apache.roller.selenium.core;
 
 import org.apache.roller.selenium.AbstractRollerPage;
 import org.apache.roller.selenium.view.BlogHomePage;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * represents core/Setup.jsp
@@ -41,6 +36,7 @@ public class SetupPage extends AbstractRollerPage {
 
     public RegisterPage createNewUser() {
         verifyPageTitle("Front Page: Welcome to Roller!");
+        System.out.println("Current URL = " + driver.getCurrentUrl());
         clickById("a_createUser");
         return new RegisterPage(driver);
     }

--- a/it-selenium/src/test/java/org/apache/roller/selenium/core/WelcomePage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/core/WelcomePage.java
@@ -20,8 +20,6 @@ package org.apache.roller.selenium.core;
 import org.apache.roller.selenium.AbstractRollerPage;
 import org.openqa.selenium.WebDriver;
 
-import java.lang.String;
-
 /**
  * represents core/Welcome.jsp
  * Page Object after creation of a new user account (RegisterPage)

--- a/it-selenium/src/test/java/org/apache/roller/selenium/editor/AbstractEntryPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/editor/AbstractEntryPage.java
@@ -18,9 +18,6 @@
 package org.apache.roller.selenium.editor;
 
 import org.apache.roller.selenium.AbstractRollerPage;
-import org.openqa.selenium.WebDriver;
-
-import java.lang.String;
 
 /**
  * Base class for the new/edit entry pages

--- a/it-selenium/src/test/java/org/apache/roller/selenium/editor/EntryAddPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/editor/EntryAddPage.java
@@ -19,8 +19,6 @@ package org.apache.roller.selenium.editor;
 
 import org.openqa.selenium.WebDriver;
 
-import java.lang.String;
-
 /**
  * represents editor/EntryAddPage.jsp
  * Page for adding a new blog entry

--- a/it-selenium/src/test/java/org/apache/roller/selenium/editor/EntryEditPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/editor/EntryEditPage.java
@@ -20,8 +20,6 @@ package org.apache.roller.selenium.editor;
 import org.apache.roller.selenium.view.SingleBlogEntryPage;
 import org.openqa.selenium.WebDriver;
 
-import java.lang.String;
-
 /**
  * represents editor/EntryEditPage.jsp
  * Page for editing an already saved (draft or posted) blog entry

--- a/it-selenium/src/test/java/org/apache/roller/selenium/view/BlogHomePage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/view/BlogHomePage.java
@@ -21,8 +21,6 @@ import org.apache.roller.selenium.AbstractRollerPage;
 import org.apache.roller.selenium.editor.EntryAddPage;
 import org.openqa.selenium.WebDriver;
 
-import java.lang.String;
-
 /**
  * Represents a URL for the home page of a blog
  * (URL similar to http://localhost:8080/roller/myblog)

--- a/it-selenium/src/test/java/org/apache/roller/selenium/view/SingleBlogEntryPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/view/SingleBlogEntryPage.java
@@ -20,8 +20,6 @@ package org.apache.roller.selenium.view;
 import org.apache.roller.selenium.AbstractRollerPage;
 import org.openqa.selenium.WebDriver;
 
-import java.lang.String;
-
 /**
  * represents a URL that displays a single blog entry
  * (URL similar to http://localhost:8080/roller/myblog/entry/my_blog_entry)

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,6 @@ limitations under the License.
     <version>6.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <prerequisites>
-        <maven>3.0.5</maven>
-    </prerequisites>
-
     <name>Roller</name>
     <description>
         Roller is an open source blog server built with open source Java
@@ -47,7 +43,10 @@ limitations under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <derby.version>10.11.1.1</derby.version>
+        <jaxb.version>2.3.1</jaxb.version>
+        <jetty.version>10.0.0</jetty.version>
         <roller.version>6.1.0-SNAPSHOT</roller.version>
+        <spring.version>5.2.7.RELEASE</spring.version>
     </properties>
 
     <modules>
@@ -80,7 +79,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
-                    <version>9.4.17.v20190418</version>
+                    <version>${jetty.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>com.btmatthews.maven.plugins.inmemdb</groupId>
@@ -110,6 +109,13 @@ limitations under the License.
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>5.6.2</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>${spring.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This commit fixes both the Maven `jetty:run` target and the it-selenium tests, upgrades Jetty to v10 and Selenium to 3.14.0. I left the it-selenium commented out in the parent POM because it requires that geckodriver be installed.