### PR TITLE
back-out change to Spring dependency

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -55,6 +55,7 @@ limitations under the License.
         <maven-antrun.version>1.0b3</maven-antrun.version>
         <rome.version>1.13.1</rome.version>
         <slf4j.version>1.7.30</slf4j.version>
+        <spring.version>5.2.7.RELEASE</spring.version>
         <spring.security.version>5.3.3.RELEASE</spring.security.version>
         <struts.version>2.5.22</struts.version>
         <velocity.version>2.2</velocity.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@ limitations under the License.
         <jaxb.version>2.3.1</jaxb.version>
         <jetty.version>10.0.0</jetty.version>
         <roller.version>6.1.0-SNAPSHOT</roller.version>
-        <spring.version>5.2.7.RELEASE</spring.version>
     </properties>
 
     <modules>
@@ -109,13 +108,6 @@ limitations under the License.
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>5.6.2</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-framework-bom</artifactId>
-                <version>${spring.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This change did not really improve the Jetty warnings about classes being loaded from two locations so I'm backing it out.