### PR TITLE
Ipbanlist fixes

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -554,6 +554,20 @@ limitations under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.7.7</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.19.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
             <version>${ant.version}</version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -554,13 +554,6 @@ limitations under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>3.19.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
             <version>${ant.version}</version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -554,13 +554,6 @@ limitations under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.7.7</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.19.0</version>

--- a/app/src/main/java/org/apache/roller/weblogger/util/IPBanList.java
+++ b/app/src/main/java/org/apache/roller/weblogger/util/IPBanList.java
@@ -22,6 +22,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.PrintWriter;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -43,7 +44,7 @@ public final class IPBanList {
     private static Log log = LogFactory.getLog(IPBanList.class);
 
     // set of ips that are banned, use a set to ensure uniqueness
-    private Set bannedIps = new HashSet();
+    private volatile Set<String> bannedIps = Collections.synchronizedSet(new HashSet<>());
 
     // file listing the ips that are banned
     private ModifiedFile bannedIpsFile = null;
@@ -150,7 +151,7 @@ public final class IPBanList {
 
             // TODO: optimize this
             try (BufferedReader in = new BufferedReader(new FileReader(this.bannedIpsFile))) {
-                HashSet newBannedIpList = new HashSet();
+                Set<String> newBannedIpList = new HashSet<>();
 
                 String ip = null;
                 while((ip = in.readLine()) != null) {
@@ -158,7 +159,7 @@ public final class IPBanList {
                 }
 
                 // list updated, reset modified file
-                this.bannedIps = newBannedIpList;
+                this.bannedIps = Collections.synchronizedSet(newBannedIpList);
                 this.bannedIpsFile.clearChanged();
 
                 log.info(this.bannedIps.size()+" banned ips loaded");

--- a/app/src/main/java/org/apache/roller/weblogger/util/IPBanList.java
+++ b/app/src/main/java/org/apache/roller/weblogger/util/IPBanList.java
@@ -24,6 +24,8 @@ import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Supplier;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.roller.weblogger.config.WebloggerConfig;
@@ -51,17 +53,17 @@ public final class IPBanList {
 
 
     static {
-        instance = new IPBanList();
+        instance = new IPBanList(() -> WebloggerConfig.getProperty("ipbanlist.file"));
     }
 
 
-    // private because we are a singleton
-    private IPBanList() {
+    // package-private for unit tests
+    IPBanList(Supplier<String> banIpsFilePathSupplier) {
 
         log.debug("INIT");
 
         // load up set of denied ips
-        String banIpsFilePath = WebloggerConfig.getProperty("ipbanlist.file");
+        String banIpsFilePath = banIpsFilePathSupplier.get();
         if(banIpsFilePath != null) {
             ModifiedFile banIpsFile = new ModifiedFile(banIpsFilePath);
 

--- a/app/src/main/java/org/apache/roller/weblogger/util/IPBanList.java
+++ b/app/src/main/java/org/apache/roller/weblogger/util/IPBanList.java
@@ -84,7 +84,7 @@ public final class IPBanList {
     public boolean isBanned(String ip) {
 
         // update the banned ips list if needed
-        this.loadBannedIpsIfNeeded(false);
+        this.loadBannedIpsIfNeeded();
 
         if(ip != null) {
             return this.bannedIps.contains(ip);
@@ -101,7 +101,7 @@ public final class IPBanList {
         }
 
         // update the banned ips list if needed
-        this.loadBannedIpsIfNeeded(false);
+        this.loadBannedIpsIfNeeded();
 
         if(!this.bannedIps.contains(ip) &&
                 (bannedIpsFile != null && bannedIpsFile.canWrite())) {
@@ -129,10 +129,10 @@ public final class IPBanList {
     /**
      * Check if the banned ips file has changed and needs to be reloaded.
      */
-    private void loadBannedIpsIfNeeded(boolean forceLoad) {
+    private void loadBannedIpsIfNeeded() {
 
         if(bannedIpsFile != null &&
-                (bannedIpsFile.hasChanged() || forceLoad)) {
+                (bannedIpsFile.hasChanged())) {
 
             // need to reload
             this.loadBannedIps();

--- a/app/src/main/java/org/apache/roller/weblogger/util/IPBanList.java
+++ b/app/src/main/java/org/apache/roller/weblogger/util/IPBanList.java
@@ -41,7 +41,7 @@ import org.apache.roller.weblogger.config.WebloggerConfig;
  */
 public final class IPBanList {
 
-    private static Log log = LogFactory.getLog(IPBanList.class);
+    private static final Log log = LogFactory.getLog(IPBanList.class);
 
     // set of ips that are banned, use a set to ensure uniqueness
     private volatile Set<String> bannedIps = Collections.synchronizedSet(new HashSet<>());
@@ -173,7 +173,7 @@ public final class IPBanList {
 
     // a simple extension to the File class which tracks if the file has
     // changed since the last time we checked
-    private class ModifiedFile extends java.io.File {
+    private static class ModifiedFile extends java.io.File {
 
         private long myLastModified = 0;
 

--- a/app/src/test/java/org/apache/roller/weblogger/util/IPBanListTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/util/IPBanListTest.java
@@ -11,7 +11,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IPBanListTest {
 
@@ -32,7 +34,9 @@ class IPBanListTest {
     void addBannedAddsToFile() {
         sut.addBannedIp("10.0.0.1");
 
-        assertThat(readIpBanList()).containsOnly("10.0.0.1");
+        List<String> ipBanList = readIpBanList();
+        assertTrue(ipBanList.contains("10.0.0.1"));
+        assertEquals(1, ipBanList.size());
     }
 
     @Test
@@ -40,7 +44,7 @@ class IPBanListTest {
     void addBannedIgnoresNulls() {
         sut.addBannedIp(null);
 
-        assertThat(readIpBanList()).isEmpty();
+        assertTrue(readIpBanList().isEmpty());
     }
 
     @Test
@@ -48,19 +52,19 @@ class IPBanListTest {
     void isBanned() {
         sut.addBannedIp("10.0.0.1");
 
-        assertThat(sut.isBanned("10.0.0.1")).isTrue();
+        assertTrue(sut.isBanned("10.0.0.1"));
     }
 
     @Test
     @DisplayName("isBanned() returns false if the given IP address it not banned")
     void isBanned2() {
-        assertThat(sut.isBanned("10.0.0.1")).isFalse();
+        assertFalse(sut.isBanned("10.0.0.1"));
     }
 
     @Test
     @DisplayName("isBanned() returns false if the given IP address is null")
     void isBanned3() {
-        assertThat(sut.isBanned(null)).isFalse();
+        assertFalse(sut.isBanned(null));
     }
 
     @Test
@@ -68,7 +72,7 @@ class IPBanListTest {
     void isBanned4() {
         writeIpBanList("10.0.0.1");
 
-        assertThat(sut.isBanned("10.0.0.1")).isTrue();
+        assertTrue(sut.isBanned("10.0.0.1"));
     }
 
     private void writeIpBanList(String ipAddress) {

--- a/app/src/test/java/org/apache/roller/weblogger/util/IPBanListTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/util/IPBanListTest.java
@@ -1,0 +1,89 @@
+package org.apache.roller.weblogger.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IPBanListTest {
+
+    @TempDir
+    Path tmpDir;
+    Path ipBanList;
+    IPBanList sut;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        ipBanList = tmpDir.resolve("ipbanlist.txt");
+        Files.createFile(ipBanList);
+        sut = new IPBanList(() -> ipBanList.toAbsolutePath().toString());
+    }
+
+    @Test
+    @DisplayName("addBanned() adds the given IP address to the file")
+    void addBannedAddsToFile() {
+        sut.addBannedIp("10.0.0.1");
+
+        assertThat(readIpBanList()).containsOnly("10.0.0.1");
+    }
+
+    @Test
+    @DisplayName("addBanned() ignores nulls")
+    void addBannedIgnoresNulls() {
+        sut.addBannedIp(null);
+
+        assertThat(readIpBanList()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("isBanned() returns true if the given IP address is banned")
+    void isBanned() {
+        sut.addBannedIp("10.0.0.1");
+
+        assertThat(sut.isBanned("10.0.0.1")).isTrue();
+    }
+
+    @Test
+    @DisplayName("isBanned() returns false if the given IP address it not banned")
+    void isBanned2() {
+        assertThat(sut.isBanned("10.0.0.1")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBanned() returns false if the given IP address is null")
+    void isBanned3() {
+        assertThat(sut.isBanned(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBanned() reads the file if needed")
+    void isBanned4() {
+        writeIpBanList("10.0.0.1");
+
+        assertThat(sut.isBanned("10.0.0.1")).isTrue();
+    }
+
+    private void writeIpBanList(String ipAddress) {
+        try {
+            Files.writeString(ipBanList, ipAddress);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private List<String> readIpBanList() {
+        try {
+            return Files.readAllLines(ipBanList);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}


### PR DESCRIPTION
Fixes some concurrency issues in the IPBanList class:

* It calls HashSet#contains() from outside a synchronized block: it might not be able to catch a change made by a different thread
* The bannedIps field is not volatile even though multiple threads can set it to a new instance from loadBannedIps(): other threads might not see the updated instance

There are also some minor code improvements suggested by IntelliJ