### PR TITLE
Fixed: type specification when using generics

### DIFF
--- a/app/src/main/java/org/apache/roller/planet/business/jpa/JPAPlanetManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/planet/business/jpa/JPAPlanetManagerImpl.java
@@ -205,7 +205,7 @@ public class JPAPlanetManagerImpl extends AbstractManagerImpl implements PlanetM
     }
     
     public List<String> getGroupHandles(Planet planet) throws RollerException {
-        List<String> handles = new ArrayList<String>();
+        List<String> handles = new ArrayList<>();
         for (PlanetGroup group : getGroups(planet)) {
             handles.add(group.getHandle());
         }
@@ -283,7 +283,7 @@ public class JPAPlanetManagerImpl extends AbstractManagerImpl implements PlanetM
             long startTime = System.currentTimeMillis();
             
             StringBuilder sb = new StringBuilder();
-            List<Object> params = new ArrayList<Object>();
+            List<Object> params = new ArrayList<>();
             int size = 0;
             sb.append("SELECT e FROM SubscriptionEntry e ");
             sb.append("JOIN e.subscription.groups g ");


### PR DESCRIPTION
Java 7 introduced the diamond operator (<>) to reduce the verbosity of generics code. For instance, instead of having to declare a List's type in both its declaration and its constructor, you can now simplify the constructor declaration with <>, and the compiler will infer the type.

Issue found using Sonar Cube.