### PR TITLE
Added Roller 6.1 db table upgrade logic + maven dependency upgrades

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -39,26 +39,26 @@ limitations under the License.
         <java-mail.version>1.4.7</java-mail.version>
         <jstl.version>1.2</jstl.version>
         <angular.version>1.7.8</angular.version>
-        <ant.version>1.10.8</ant.version>
-        <asm.version>9.0-beta</asm.version>
+        <ant.version>1.10.9</ant.version>
+        <asm.version>9.1</asm.version>
         <commons-validator.version>1.7</commons-validator.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-httpclient.version>3.1</commons-httpclient.version>
         <commons-codec.version>1.15</commons-codec.version>
-        <eclipse-link.version>2.7.7</eclipse-link.version>
-        <guice.version>4.2.3</guice.version>
-        <log4j2.version>2.13.3</log4j2.version>
-        <lucene.version>8.6.2</lucene.version>
+        <eclipse-link.version>2.7.8</eclipse-link.version>
+        <guice.version>5.0.1</guice.version>
+        <log4j2.version>2.14.1</log4j2.version>
+        <lucene.version>8.8.1</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
         <maven-war.version>3.2.3</maven-war.version>
-        <maven-surefire.version>2.17</maven-surefire.version>
+        <maven-surefire.version>2.22.2</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
         <rome.version>1.15.0</rome.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <spring.version>5.2.9.RELEASE</spring.version>
-        <spring.security.version>5.4.0</spring.security.version>
-        <struts.version>2.5.22</struts.version>
-        <velocity.version>2.2</velocity.version>
+        <spring.version>5.3.5</spring.version>
+        <spring.security.version>5.4.5</spring.security.version>
+        <struts.version>2.5.26</struts.version>
+        <velocity.version>2.3</velocity.version>
         <webjars.version>1.5</webjars.version>
         <ws-commons-util.version>1.0.2</ws-commons-util.version>
         <xml-security.version>1.3.0</xml-security.version>
@@ -251,23 +251,24 @@ limitations under the License.
             <artifactId>struts2-tiles-plugin</artifactId>
             <version>${struts.version}</version>
         </dependency>
-
+        
+        <!-- note: update head.jsp on webjar version change -->
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>3.3.7</version>
+            <version>3.4.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>clipboard.js</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.6</version>
         </dependency>
 
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>3.3.1</version>
+            <version>3.6.0</version>
         </dependency>
 
         <dependency>
@@ -279,13 +280,13 @@ limitations under the License.
         <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>summernote</artifactId>
-            <version>0.8.11</version>
+            <version>0.8.12</version>
         </dependency>
 
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery-validation</artifactId>
-            <version>1.19.0</version>
+            <version>1.19.3</version>
         </dependency>
 
         <dependency>
@@ -499,7 +500,6 @@ limitations under the License.
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>${guice.version}</version>
-            <classifier>no_aop</classifier>
             <exclusions>
                 <exclusion>
                     <groupId>aopalliance</groupId>
@@ -744,7 +744,7 @@ limitations under the License.
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>${maven-surefire.version}</version>
                 <configuration>
                     <systemProperties>
                         <property>

--- a/app/src/main/java/org/apache/roller/weblogger/business/startup/DatabaseInstaller.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/startup/DatabaseInstaller.java
@@ -246,6 +246,10 @@ public class DatabaseInstaller {
                 upgradeTo520(con, runScripts);
                 dbversion = 520;
             }
+            if(dbversion < 610) {
+                upgradeTo610(con, runScripts);
+                dbversion = 610;
+            }
 
             // make sure the database version is the exact version
             // we are upgrading too.
@@ -709,80 +713,56 @@ public class DatabaseInstaller {
      * Upgrade database to Roller 5.0
      */
     private void upgradeTo500(Connection con, boolean runScripts) throws StartupException {
-
-        // first we need to run upgrade scripts
-        SQLScriptRunner runner = null;
-        try {
-            if (runScripts) {
-                String handle = getDatabaseHandle(con);
-                String scriptPath = handle + "/400-to-500-migration.sql";
-                successMessage("Running database upgrade script: "+scriptPath);
-                runner = new SQLScriptRunner(scripts.getDatabaseScript(scriptPath));
-                runner.runScript(con, true);
-                messages.addAll(runner.getMessages());
-            }
-        } catch(Exception ex) {
-            log.error("ERROR running 500 database upgrade script", ex);
-            if (runner != null) {
-                messages.addAll(runner.getMessages());
-            }
-
-            errorMessage("Problem upgrading database to version 500", ex);
-            throw new StartupException("Problem upgrading database to version 500", ex);
-        }
+        simpleUpgrade(con, 400, 500, runScripts);      
     }
 
     /**
      * Upgrade database to Roller 5.1
      */
 	private void upgradeTo510(Connection con, boolean runScripts) throws StartupException {
-
-        // first we need to run upgrade scripts
-        SQLScriptRunner runner = null;
-        try {
-            if (runScripts) {
-                String handle = getDatabaseHandle(con);
-                String scriptPath = handle + "/500-to-510-migration.sql";
-                successMessage("Running database upgrade script: "+scriptPath);
-                runner = new SQLScriptRunner(scripts.getDatabaseScript(scriptPath));
-                runner.runScript(con, true);
-                messages.addAll(runner.getMessages());
-            }
-        } catch(Exception ex) {
-            log.error("ERROR running 510 database upgrade script", ex);
-            if (runner != null) {
-                messages.addAll(runner.getMessages());
-            }
-
-            errorMessage("Problem upgrading database to version 510", ex);
-            throw new StartupException("Problem upgrading database to version 510", ex);
-        }
+        simpleUpgrade(con, 500, 510, runScripts);
 	}
 
     /**
      * Upgrade database to Roller 5.2
      */
     private void upgradeTo520(Connection con, boolean runScripts) throws StartupException {
+        simpleUpgrade(con, 510, 520, runScripts);
+    }
+
+    /**
+     * Upgrade database to Roller 6.1
+     */
+    private void upgradeTo610(Connection con, boolean runScripts) throws StartupException {
+        simpleUpgrade(con, 520, 610, runScripts);
+    }
+    
+    /**
+     * Simple upgrade using single SQL migration script.
+     */
+    private void simpleUpgrade(Connection con, int fromVersion, int toVersion, boolean runScripts) throws StartupException {
 
         // first we need to run upgrade scripts
         SQLScriptRunner runner = null;
         try {
             if (runScripts) {
                 String handle = getDatabaseHandle(con);
-                String scriptPath = handle + "/510-to-520-migration.sql";
+                String scriptPath = handle + "/"+fromVersion+"-to-"+toVersion+"-migration.sql";
+                
                 successMessage("Running database upgrade script: "+scriptPath);
+                
                 runner = new SQLScriptRunner(scripts.getDatabaseScript(scriptPath));
                 runner.runScript(con, true);
                 messages.addAll(runner.getMessages());
             }
         } catch(Exception ex) {
-            log.error("ERROR running 520 database upgrade script", ex);
+            log.error("ERROR running "+fromVersion+"->"+toVersion+" database upgrade script", ex);
             if (runner != null) {
                 messages.addAll(runner.getMessages());
             }
 
-            errorMessage("Problem upgrading database to version 520", ex);
-            throw new StartupException("Problem upgrading database to version 520", ex);
+            errorMessage("Problem upgrading database to version "+toVersion, ex);
+            throw new StartupException("Problem upgrading database to version "+toVersion, ex);
         }
     }
 

--- a/app/src/main/resources/sql/520-to-610-migration.vm
+++ b/app/src/main/resources/sql/520-to-610-migration.vm
@@ -1,0 +1,7 @@
+#**
+ 520-to-610-migration.vm: Velocity template that generates vendor-specific database scripts
+
+ DON'T RUN THIS, IT'S NOT A DATABASE CREATION SCRIPT!!!
+ **#
+
+#alterColumnName('weblog' 'blacklist' 'bannedwordslist')

--- a/app/src/main/resources/sql/dbscripts.properties
+++ b/app/src/main/resources/sql/dbscripts.properties
@@ -6,4 +6,4 @@ databases=db2 derby hsqldb mssql mysql oracle postgresql
 
 # list all db templates to generate, separated by spaces
 templates=createdb 310-to-400-migration 400-to-500-migration  \
-500-to-510-migration 510-to-520-migration
+500-to-510-migration 510-to-520-migration 520-to-610-migration

--- a/app/src/main/resources/sql/macros.vm
+++ b/app/src/main/resources/sql/macros.vm
@@ -161,3 +161,17 @@ alter table $tableName alter column $columnName $columnType;
 -- You should alter type of column $columnName of table $tableName to $columnType
 #end
 #end
+
+#**
+Rename a table column.
+this is trivial generic SQL - this should work everywhere, right?
+**#
+#macro(alterColumnName $tableName $columnName $newColumnName)
+#if ($db.DBTYPE == "MSSQL")
+sp_rename '$tableName.$columnName', '$newColumnName', 'COLUMN';
+#elseif ($db.DBTYPE == "HSQLDB")
+alter table $tableName alter column $columnName rename to $newColumnName;
+#else
+alter table $tableName rename column $columnName to $newColumnName;
+#end
+#end

--- a/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
@@ -5,21 +5,21 @@ You can override it with your own file via WEB-INF/tiles-def.xml
 
 <%@ include file="/WEB-INF/jsps/taglibs-struts2.jsp" %>
 
-<script src="<s:url value='/webjars/jquery/3.3.1/jquery.min.js' />"></script>
+<script src="<s:url value='/webjars/jquery/3.6.0/jquery.min.js' />"></script>
 
 <script src="<s:url value='/webjars/jquery-ui/1.12.1/jquery-ui.min.js' />"></script>
 <link href="<s:url value='/webjars/jquery-ui/1.12.1/jquery-ui.css' />" rel="stylesheet" />
 
-<script src="<s:url value='/webjars/jquery-validation/1.19.0/jquery.validate.min.js' />"></script>
+<script src="<s:url value='/webjars/jquery-validation/1.19.3/jquery.validate.min.js' />"></script>
 
-<link href="<s:url value='/webjars/bootstrap/3.3.7/css/bootstrap.min.css' />" rel="stylesheet" />
-<link href="<s:url value='/webjars/bootstrap/3.3.7/css/bootstrap-theme.min.css' />" rel="stylesheet" />
-<script src="<s:url value='/webjars/bootstrap/3.3.7/js/bootstrap.min.js' />"></script>
+<link href="<s:url value='/webjars/bootstrap/3.4.1/css/bootstrap.min.css' />" rel="stylesheet" />
+<link href="<s:url value='/webjars/bootstrap/3.4.1/css/bootstrap-theme.min.css' />" rel="stylesheet" />
+<script src="<s:url value='/webjars/bootstrap/3.4.1/js/bootstrap.min.js' />"></script>
 
-<script src="<s:url value='/webjars/clipboard.js/2.0.0/clipboard.min.js' />"></script>
+<script src="<s:url value='/webjars/clipboard.js/2.0.6/clipboard.min.js' />"></script>
 
-<script src="<s:url value='/webjars/summernote/0.8.11/dist/summernote.min.js' />"></script>
-<link href="<s:url value='/webjars/summernote/0.8.11/dist/summernote.css' />" rel="stylesheet" />
+<script src="<s:url value='/webjars/summernote/0.8.12/dist/summernote.min.js' />"></script>
+<link href="<s:url value='/webjars/summernote/0.8.12/dist/summernote.css' />" rel="stylesheet" />
 
 <link rel="stylesheet" media="all" href='<s:url value="/roller-ui/styles/roller.css"/>' />
 

--- a/it-selenium/pom.xml
+++ b/it-selenium/pom.xml
@@ -120,7 +120,14 @@
 
     <build>
         <plugins>
-
+            
+            <!-- bump plugin version for JDK 16 compatibility (old guice version),
+                 can be removed once maven itself bumped the version -->
+            <plugin>
+               <artifactId>maven-war-plugin</artifactId>
+               <version>3.3.1</version>
+            </plugin>
+             
             <!-- Activates integration tests (by default, classes under tests that end with "IT") -->
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.8.1</version>
                     <configuration>
                         <rulesUri>file:version-rules.xml</rulesUri>
                     </configuration>
@@ -106,7 +106,7 @@ limitations under the License.
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.6.2</version>
+                <version>5.7.1</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
The table name change requires an upgrade script. Its very generic SQL but don't know on how many DBs this is going to work. I only tested it with HSQLDB.

updated maven dependencies
 - guice 5 can be used again without the noaop tag on latest jdks
 - asm, spring, lucene, velocity etc
 
updated webjars
 - bootstrap 3.4.1 is the last version before 4.x which comes with breaking changes
 
checked JDK16 compatibility
 - required war plugin update in selenium pom

