### PR TITLE
Remove provided scope for JSTL

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -87,7 +87,6 @@ limitations under the License.
             <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
             <version>${jstl.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR removes provided scope for JSTL becuase JSTL is not provided by Tomcat. I erroneously added provided scope a couple months ago when I was trying to get the Maven Jetty stuff working.