### PR TITLE
Improved: the UI for the blog entries page

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsps/editor/Entries.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Entries.jsp
@@ -63,11 +63,11 @@
 <table class="rollertable table table-striped" width="100%">
 
 <tr>
-    <th class="rollertable" width="5%"> </th>
-    <th class="rollertable" width="5%">
+    <th class="rollertable" width="3%"> </th>
+    <th class="rollertable" width="7%">
         <s:text name="weblogEntryQuery.pubTime" />
     </th>
-    <th class="rollertable" width="5%">
+    <th class="rollertable" width="7%">
         <s:text name="weblogEntryQuery.updateTime" />
     </th>
     <th class="rollertable">
@@ -76,7 +76,7 @@
     <th class="rollertable" width="15%">
         <s:text name="weblogEntryQuery.category" />
     </th>
-    <th class="rollertable" width="5%"> </th>
+    <th class="rollertable" width="3%"> </th>
 </tr>
 
 <s:iterator var="post" value="pager.items">


### PR DESCRIPTION
Made the same UI for the published column and updated column in the blog entries table.
Also, reduced the width to 3% for the edit icon and delete icon column in the same table.

*Before:*

![image](https://user-images.githubusercontent.com/41404838/118253791-f3ff0480-b4c7-11eb-8ccd-88d0d4764387.png)

*After:*

![image](https://user-images.githubusercontent.com/41404838/118253849-0711d480-b4c8-11eb-92b7-bac9952d3c95.png)
