### PR TITLE
fix for PropertyNotFoundException when started in WildFly

### DIFF
--- a/app/src/main/java/org/apache/roller/weblogger/pojos/WeblogEntryComment.java
+++ b/app/src/main/java/org/apache/roller/weblogger/pojos/WeblogEntryComment.java
@@ -291,10 +291,6 @@ public class WeblogEntryComment implements Serializable {
     public Boolean getApproved() {
         return ApprovalStatus.APPROVED.equals(getStatus());
     }
-
-    public String getEmptyString() {
-        return "";
-    }
     
     
     /**

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Comments.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Comments.jsp
@@ -211,16 +211,16 @@
                         <%-- only blog admins (not the global admin) can approve blog comments --%>
                         <td>
                             <s:checkboxlist name="bean.approvedComments" cssClass="comment-select"
-                                            list="#comment" listKey="id" listValue="emptyString" />
+                                            list="#comment" listKey="id" listValue="" />
                         </td>
                     </s:if>
                     <td>
                         <s:checkboxlist name="bean.spamComments" cssClass="comment-select"
-                                        list="#comment" listKey="id" listValue="emptyString"  />
+                                        list="#comment" listKey="id" listValue="" />
                     </td>
                     <td>
                         <s:checkboxlist name="bean.deleteComments" cssClass="comment-select"
-                                        list="#comment" listKey="id" listValue="emptyString"  />
+                                        list="#comment" listKey="id" listValue="" />
                     </td>
 
                         <%-- ======================================================== --%>


### PR DESCRIPTION
second attempt of https://github.com/apache/roller/pull/64

removed getEmptyString() since listValue="" has the same effect and makes WildFly happy too.