### PR TITLE
Updated: the main menu to have proper space when displaying permission message

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsps/core/MainMenu.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/core/MainMenu.jsp
@@ -72,9 +72,9 @@
             <p><s:property value="#perms.weblog.about" escapeHtml="false" /></p>
 
             <p>You have 
-            <s:if test='#perms.hasAction("admin")'>ADMIN</s:if>
-            <s:if test='#perms.hasAction("post")'>AUTHOR</s:if>
-            <s:if test='#perms.hasAction("edit_draft")'>LIMITED</s:if>
+            <s:if test='#perms.hasAction("admin")'>ADMIN </s:if>
+            <s:if test='#perms.hasAction("post")'>AUTHOR </s:if>
+            <s:if test='#perms.hasAction("edit_draft")'>LIMITED </s:if>
             <s:text name='yourWebsites.permission'/></p>
             
             <div class="btn-group" role="group" aria-label="...">


### PR DESCRIPTION
Added space between the permission message.

Before:
![image](https://user-images.githubusercontent.com/41404838/124945347-b03dfc80-e02b-11eb-93a0-adef4b2ae5a3.png)


After:
![image](https://user-images.githubusercontent.com/41404838/124945127-81278b00-e02b-11eb-9e07-284ac0dba5ad.png)
