### PR TITLE
Velocity property warning fixes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,9 +40,6 @@ jobs:
       with:
         java-version: 11
 
-    - name: Build with Maven
-      run: mvn -DskipTests=true install
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
@@ -53,21 +50,8 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - name: Build with Maven
+      run: mvn -DskipTests=true -V -ntp install
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/app/src/main/java/org/apache/roller/planet/tasks/GeneratePlanetTask.java
+++ b/app/src/main/java/org/apache/roller/planet/tasks/GeneratePlanetTask.java
@@ -40,7 +40,7 @@ import org.apache.velocity.app.VelocityEngine;
  */
 public class GeneratePlanetTask extends PlanetTask {
     
-    private static Log log = LogFactory.getLog(GeneratePlanetTask.class);
+    private static final Log log = LogFactory.getLog(GeneratePlanetTask.class);
     
     
     @Override
@@ -68,7 +68,7 @@ public class GeneratePlanetTask extends PlanetTask {
 
             // Fire up Velocity engine, point it at templates and init
             VelocityEngine engine = new VelocityEngine();
-            engine.setProperty("resource.loader","file");
+            engine.setProperty("resource.loaders", "file");
             engine.setProperty("file.resource.loader.class",
               "org.apache.velocity.runtime.resource.loader.FileResourceLoader");
             engine.setProperty("file.resource.loader.path", templateDir);

--- a/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/RollerVelocity.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/RollerVelocity.java
@@ -63,10 +63,10 @@ public class RollerVelocity {
             
             // Override for theme reloading
             if (themeReload) {
-                velocityProps.setProperty("class.resource.loader.cache", "false");
-                velocityProps.setProperty("class.resource.loader.modificationCheckInterval", "2");
-                velocityProps.setProperty("webapp.resource.loader.cache", "false");
-                velocityProps.setProperty("webapp.resource.loader.modificationCheckInterval", "2");
+                velocityProps.setProperty("resource.loader.class.cache", "false");
+                velocityProps.setProperty("resource.loader.class.modification_check_interval", "2");
+                velocityProps.setProperty("resource.loader.webapp.cache", "false");
+                velocityProps.setProperty("resource.loader.webapp.modification_check_interval", "2");
                 velocityProps.setProperty("velocimacro.library.autoreload", "true");
             }
            

--- a/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/WebappResourceLoader.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/WebappResourceLoader.java
@@ -49,15 +49,15 @@ import org.apache.velocity.util.ExtProperties;
  * 
  * The default search path is '/' (relative to the webapp root), but you can
  * change this behaviour by specifying one or more paths by mean of as many
- * webapp.resource.loader.path properties as needed in the velocity.properties
+ * resource.loader.webapp.path properties as needed in the velocity.properties
  * file.
  * 
  * All paths must be relative to the root of the webapp.
  * 
- * To enable caching and cache refreshing the webapp.resource.loader.cache and
- * webapp.resource.loader.modificationCheckInterval properties need to be set in
+ * To enable caching and cache refreshing the resource.loader.webapp.cache and
+ * resource.loader.webapp.modification_check_interval properties need to be set in
  * the velocity.properties file ... auto-reloading of global macros requires the
- * webapp.resource.loader.cache property to be set to 'false'.
+ * resource.loader.webapp.cache property to be set to 'false'.
  * 
  */
 public class WebappResourceLoader extends ResourceLoader {

--- a/app/src/main/resources/log4j2.xml
+++ b/app/src/main/resources/log4j2.xml
@@ -70,7 +70,7 @@ limitations under the License.
         
         <!-- roller.log; everything not defined here will end up in server.log -->
         <Logger name="org.apache.roller"       level="info"  additivity="false"> <AppenderRef ref="asyncRoller"/> </Logger>
-        <Logger name="org.apache.velocity"     level="error" additivity="false"> <AppenderRef ref="asyncRoller"/> </Logger>
+        <Logger name="org.apache.velocity"     level="info"  additivity="false"> <AppenderRef ref="asyncRoller"/> </Logger>
         <Logger name="org.springframework"     level="info"  additivity="false"> <AppenderRef ref="asyncRoller"/> </Logger>
         <Logger name="org.apache.struts2"      level="info"  additivity="false"> <AppenderRef ref="asyncRoller"/> </Logger>
         <Logger name="org.openid4java"         level="info"  additivity="false"> <AppenderRef ref="asyncRoller"/> </Logger>

--- a/app/src/main/webapp/WEB-INF/jsps/tiles/search.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/tiles/search.jsp
@@ -34,7 +34,7 @@
         style="margin: 0; padding: 0" onsubmit="return validateSearch(this)">
         <input type="text" id="q" name="q" size="20"
             maxlength="255" value="<c:out value="${param.q}" />" />
-        <input value="&nbsp;»&nbsp;" class="searchButton" type="submit">
+        <input value="&nbsp;Â»&nbsp;" class="searchButton" type="submit">
      </form>
      <script type="text/javascript"> 
         // <!--

--- a/app/src/main/webapp/WEB-INF/velocity.properties
+++ b/app/src/main/webapp/WEB-INF/velocity.properties
@@ -15,34 +15,34 @@
 # directory of this distribution.
 
 # specify resource loaders to use
-resource.loader = webapp, theme, roller, class
+resource.loaders = webapp, theme, roller, class
 
 # theme resource loader
-theme.resource.loader.public.name=theme
-theme.resource.loader.description=Roller Theme Resource Loader
-theme.resource.loader.class=org.apache.roller.weblogger.ui.rendering.velocity.ThemeResourceLoader
-theme.resource.loader.cache=false
-theme.resource.loader.modificationCheckInterval=60
+resource.loader.theme.public.name=theme
+resource.loader.theme.description=Roller Theme Resource Loader
+resource.loader.theme.class=org.apache.roller.weblogger.ui.rendering.velocity.ThemeResourceLoader
+resource.loader.theme.cache=false
+resource.loader.theme.modification_check_interval=60
 
 # for the loader we call 'roller', use the RollerResourceLoader
-roller.resource.loader.public.name=roller
-roller.resource.loader.description=Roller Main Resource Loader
-roller.resource.loader.class=org.apache.roller.weblogger.ui.rendering.velocity.RollerResourceLoader
-roller.resource.loader.cache=false
-roller.resource.loader.modificationCheckInterval=60
+resource.loader.roller.public.name=roller
+resource.loader.roller.description=Roller Main Resource Loader
+resource.loader.roller.class=org.apache.roller.weblogger.ui.rendering.velocity.RollerResourceLoader
+resource.loader.roller.cache=false
+resource.loader.roller.modification_check_interval=60
 
 # for the loader we call 'class', use the ClasspathResourceLoader
-class.resource.loader.description = Velocity Classpath Resource Loader
-class.resource.loader.class = org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader
-class.resource.loader.cache=true
-class.resource.loader.modificationCheckInterval=60
+resource.loader.class.description = Velocity Classpath Resource Loader
+resource.loader.class.class = org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader
+resource.loader.class.cache=true
+resource.loader.class.modification_check_interval=60
 
 # for the loader we call 'webapp', use the WebappResourceLoader
-webapp.resource.loader.description=Webapp Resource Loader
-webapp.resource.loader.class=org.apache.roller.weblogger.ui.rendering.velocity.WebappResourceLoader
-webapp.resource.loader.cache=true
-webapp.resource.loader.path=/WEB-INF/velocity,/WEB-INF/velocity/templates,/WEB-INF/velocity/templates/feeds,templates/weblog,templates/planet
-webapp.resource.loader.modificationCheckInterval=60
+resource.loader.webapp.description=Webapp Resource Loader
+resource.loader.webapp.class=org.apache.roller.weblogger.ui.rendering.velocity.WebappResourceLoader
+resource.loader.webapp.cache=true
+resource.loader.webapp.path=/WEB-INF/velocity,/WEB-INF/velocity/templates,/WEB-INF/velocity/templates/feeds,templates/weblog,templates/planet
+resource.loader.webapp.modification_check_interval=60
 
 # log invalid template references?
 # set this to false to have a quieter velocity.log
@@ -53,21 +53,21 @@ runtime.log.logsystem.class=org.apache.velocity.runtime.log.SimpleLog4JLogSystem
 runtime.log.logsystem.log4j.category=org.apache.velocity
 
 # Override the default global library, set to blank to load no default
-velocimacro.library = weblog.vm,feeds.vm,roller-custom.vm
+velocimacro.library.path = weblog.vm,feeds.vm,roller-custom.vm
 
-# See RollerVelocity for reloading "webapp.resource.loader.path" files via WebappResourceLoader settings
+# See RollerVelocity for reloading "resource.loader.webapp.path" files via WebappResourceLoader settings
 velocimacro.library.autoreload=false
 
 # Allow Velocimacros to be defined in regular templates
-velocimacro.permissions.allow.inline=true
+velocimacro.inline.allow=true
 
 # Allow template authors to define macros in any template
-velocimacro.permissions.allow.inline.local.scope=false
+velocimacro.inline.local_scope=false
 
 # set encoding/charset to UTF-8
-input.encoding=UTF-8
+resource.default_encoding=UTF-8
 output.encoding=UTF-8
 default.contentType=text/html; charset=utf-8
 
-runtime.introspector.uberspect=org.apache.velocity.util.introspection.SecureUberspector
+introspector.uberspect.class=org.apache.velocity.util.introspection.SecureUberspector
 

--- a/app/src/main/webapp/WEB-INF/velocity.properties
+++ b/app/src/main/webapp/WEB-INF/velocity.properties
@@ -52,6 +52,9 @@ runtime.log.invalid.reference=false
 runtime.log.logsystem.class=org.apache.velocity.runtime.log.SimpleLog4JLogSystem
 runtime.log.logsystem.log4j.category=org.apache.velocity
 
+# modern JVMs have fast deduplication
+runtime.string_interning=false
+
 # Override the default global library, set to blank to load no default
 velocimacro.library.path = weblog.vm,feeds.vm,roller-custom.vm
 
@@ -66,7 +69,6 @@ velocimacro.inline.local_scope=false
 
 # set encoding/charset to UTF-8
 resource.default_encoding=UTF-8
-output.encoding=UTF-8
 default.contentType=text/html; charset=utf-8
 
 introspector.uberspect.class=org.apache.velocity.util.introspection.SecureUberspector

--- a/app/src/main/webapp/WEB-INF/web.xml
+++ b/app/src/main/webapp/WEB-INF/web.xml
@@ -449,6 +449,9 @@
 
     <session-config>
         <session-timeout>30</session-timeout>
+        <cookie-config>
+            <http-only>true</http-only> <!-- prohibit JS access -->
+        </cookie-config>
     </session-config>
 
     <welcome-file-list>

--- a/app/src/test/resources/WEB-INF/velocity.properties
+++ b/app/src/test/resources/WEB-INF/velocity.properties
@@ -15,33 +15,33 @@
 # directory of this distribution.
 
 # specify resource loaders to use
-resource.loader = webapp, theme, roller, class
+resource.loaders = webapp, theme, roller, class
 
 # theme resource loader
-theme.resource.loader.public.name=theme
-theme.resource.loader.description=Roller Theme Resource Loader
-theme.resource.loader.class=org.apache.roller.weblogger.ui.rendering.velocity.ThemeResourceLoader
-theme.resource.loader.cache=false
-theme.resource.loader.modificationCheckInterval=2
+resource.loader.theme.public.name=theme
+resource.loader.theme.description=Roller Theme Resource Loader
+resource.loader.theme.class=org.apache.roller.weblogger.ui.rendering.velocity.ThemeResourceLoader
+resource.loader.theme.cache=false
+resource.loader.theme.modification_check_interval=2
 
 # for the loader we call 'roller', use the RollerResourceLoader
-roller.resource.loader.public.name=roller
-roller.resource.loader.description=Roller Main Resource Loader
-roller.resource.loader.class=org.apache.roller.weblogger.ui.rendering.velocity.RollerResourceLoader
-roller.resource.loader.cache=false
-roller.resource.loader.modificationCheckInterval=2
+resource.loader.roller.public.name=roller
+resource.loader.roller.description=Roller Main Resource Loader
+resource.loader.roller.class=org.apache.roller.weblogger.ui.rendering.velocity.RollerResourceLoader
+resource.loader.roller.cache=false
+resource.loader.roller.modification_check_interval=2
 
 # for the loader we call 'class', use the ClasspathResourceLoader
-class.resource.loader.description = Velocity Classpath Resource Loader
-class.resource.loader.class = org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader
-class.resource.loader.cache=true
-class.resource.loader.modificationCheckInterval=60
+resource.loader.class.description = Velocity Classpath Resource Loader
+resource.loader.class.class = org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader
+resource.loader.class.cache=true
+resource.loader.class.modification_check_interval=60
 
 # for the loader we call 'webapp', use the WebappResourceLoader
-webapp.resource.loader.description = Roller Webapp Resource Loader
-webapp.resource.loader.class = org.apache.roller.weblogger.ui.rendering.velocity.WebappResourceLoader
-webapp.resource.loader.cache=true
-webapp.resource.loader.modificationCheckInterval=60
+resource.loader.webapp.description = Roller Webapp Resource Loader
+resource.loader.webapp.class = org.apache.roller.weblogger.ui.rendering.velocity.WebappResourceLoader
+resource.loader.webapp.cache=true
+resource.loader.webapp.modification_check_interval=60
 
 # log invalid template references?
 # set this to false to have a quieter velocity.log
@@ -52,19 +52,19 @@ runtime.log.logsystem.class=org.apache.velocity.runtime.log.SimpleLog4JLogSystem
 runtime.log.logsystem.log4j.category=org.apache.velocity
 
 # Override the default global library, set to blank to load no default
-velocimacro.library = weblog.vm,feeds.vm,roller-custom.vm
+velocimacro.library.path = weblog.vm,feeds.vm,roller-custom.vm
 
 # Change to false for deployment environments.
 # Caching for the 'class' & 'webapp' ResourceLoaders must be false for this to work
 velocimacro.library.autoreload=true
 
 # Allow Velocimacros to be defined in regular templates
-velocimacro.permissions.allow.inline=true
+velocimacro.inline.allow=true
 
 # Allow template authors to define macros in any template
-velocimacro.permissions.allow.inline.local.scope=false
+velocimacro.inline.local_scope=false
 
 # set encoding/charset to UTF-8
-input.encoding=UTF-8
+resource.default_encoding=UTF-8
 output.encoding=UTF-8
 default.contentType=text/html; charset=utf-8

--- a/app/src/test/resources/WEB-INF/velocity.properties
+++ b/app/src/test/resources/WEB-INF/velocity.properties
@@ -51,6 +51,9 @@ runtime.log.invalid.reference=false
 runtime.log.logsystem.class=org.apache.velocity.runtime.log.SimpleLog4JLogSystem
 runtime.log.logsystem.log4j.category=org.apache.velocity
 
+# modern JVMs have fast deduplication
+runtime.string_interning=false
+
 # Override the default global library, set to blank to load no default
 velocimacro.library.path = weblog.vm,feeds.vm,roller-custom.vm
 
@@ -66,5 +69,4 @@ velocimacro.inline.local_scope=false
 
 # set encoding/charset to UTF-8
 resource.default_encoding=UTF-8
-output.encoding=UTF-8
 default.contentType=text/html; charset=utf-8


### PR DESCRIPTION
fixes usage of deprecated velocity properties. I extracted the warnings out of JFR logs and did a project wide search and replace. Log level for velocity can be set to info again I suppose.

The other commits fix an encoding issue and add a smaller security improvement for session cookies.

here the extracted list:
```
deprecation: configuration key 'class.resource.loader.cache' has been deprecated in favor of 'resource.loader.class.cache' 
deprecation: configuration key 'class.resource.loader.class' has been deprecated in favor of 'resource.loader.class.class' 
deprecation: configuration key 'class.resource.loader.description' has been deprecated in favor of 'resource.loader.class.description' 
deprecation: configuration key 'class.resource.loader.modificationCheckInterval' has been deprecated in favor of 'resource.loader.class.modificationCheckInterval' 
deprecation: configuration key 'roller.resource.loader.cache' has been deprecated in favor of 'resource.loader.roller.cache' 
deprecation: configuration key 'roller.resource.loader.class' has been deprecated in favor of 'resource.loader.roller.class' 
deprecation: configuration key 'roller.resource.loader.description' has been deprecated in favor of 'resource.loader.roller.description' 
deprecation: configuration key 'roller.resource.loader.modificationCheckInterval' has been deprecated in favor of 'resource.loader.roller.modificationCheckInterval' 
deprecation: configuration key 'roller.resource.loader.public.name' has been deprecated in favor of 'resource.loader.roller.public.name' 
deprecation: configuration key 'webapp.resource.loader.cache' has been deprecated in favor of 'resource.loader.webapp.cache' 
deprecation: configuration key 'webapp.resource.loader.class' has been deprecated in favor of 'resource.loader.webapp.class' 
deprecation: configuration key 'webapp.resource.loader.description' has been deprecated in favor of 'resource.loader.webapp.description' 
deprecation: configuration key 'webapp.resource.loader.modificationCheckInterval' has been deprecated in favor of 'resource.loader.webapp.modificationCheckInterval' 
deprecation: configuration key 'webapp.resource.loader.path' has been deprecated in favor of 'resource.loader.webapp.path'
deprecation: configuration key 'theme.resource.loader.cache' has been deprecated in favor of 'resource.loader.theme.cache' 
deprecation: configuration key 'theme.resource.loader.class' has been deprecated in favor of 'resource.loader.theme.class' 
deprecation: configuration key 'theme.resource.loader.description' has been deprecated in favor of 'resource.loader.theme.description' 
deprecation: configuration key 'theme.resource.loader.modificationCheckInterval' has been deprecated in favor of 'resource.loader.theme.modificationCheckInterval' 
deprecation: configuration key 'theme.resource.loader.public.name' has been deprecated in favor of 'resource.loader.theme.public.name' 
deprecation: configuration key 'runtime.introspector.uberspect' has been deprecated in favor of 'introspector.uberspect.class' 
deprecation: configuration key 'velocimacro.library' has been deprecated in favor of 'velocimacro.library.path' 
deprecation: configuration key 'velocimacro.permissions.allow.inline' has been deprecated in favor of 'velocimacro.inline.allow' 
deprecation: configuration key 'velocimacro.permissions.allow.inline.local.scope' has been deprecated in favor of 'velocimacro.inline.local_scope' 
deprecation: configuration key 'input.encoding' has been deprecated in favor of 'resource.default_encoding' 
deprecation: configuration key 'resource.loader' has been deprecated in favor of 'resource.loaders' 
deprecation: configuration key 'modificationCheckInterval' has been deprecated in favor of 'modification_check_interval' 
```