### PR TITLE
Updated: the header to show the tagline only when its available

### DIFF
--- a/app/src/main/webapp/themes/fauxcoly/std_header.vm
+++ b/app/src/main/webapp/themes/fauxcoly/std_header.vm
@@ -1,6 +1,8 @@
 <div id="main_title">
 <h1><a href="$url.home">$model.weblog.name</a></h1>
-<p>$model.weblog.tagline</p>
+#if($model.weblog.tagline)
+    <p>$model.weblog.tagline</p>
+#end
 </div>
 
 <div id="page_menu">

--- a/app/src/main/webapp/themes/gaurav/weblog.vm
+++ b/app/src/main/webapp/themes/gaurav/weblog.vm
@@ -20,7 +20,12 @@
 		
 		<div class="row">
 			<div class="col-lg-12">
-				<h1 class="page-header">$model.weblog.name&nbsp;<small>$model.weblog.tagline</small></h1>
+				<h1 class="page-header">$model.weblog.name&nbsp;
+				<small>
+				#if($model.weblog.tagline)
+                    $model.weblog.tagline
+                #end
+				</small></h1>
 			</div>
 	  	</div>
 	  	


### PR DESCRIPTION
Added an if condition to check whether the weblog has a tagline defined or not and if there is a tagline present then only displaying the tagline.

Before:
Tagline is always displayed.
![image](https://user-images.githubusercontent.com/41404838/126061581-5ce00b5d-67e4-465a-859e-1bf8203f1e0c.png)


After:
Tagline is only displayed when its defined
![image](https://user-images.githubusercontent.com/41404838/126061457-5f11afbf-69eb-45ca-95d2-a68e5f15974d.png)



If tagline is not present then nothing is displayed. 
![image](https://user-images.githubusercontent.com/41404838/126061446-247f03a3-fdd1-4a57-a6c9-cefdf35a3f86.png)


