### PR TITLE
CodeQL fixes

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,14 @@
+name: "Roller CodeQL config"
+
+# paths-ignore only influences interpreted languages according to the doc
+# don't scan JS files three times:
+#   - ignore test folder and source folder
+#   - target is kept to only scan what is deployed
+paths-ignore: 
+    - app/target/test-classes
+    - app/src
+
+# If you wish to specify custom queries, you can do so here or in a config file.
+# By default, queries listed here will override any specified in a config file.
+# Prefix the list here with "+" to use these queries and those in the config file.
+# queries: ./path/to/local/query, your-org/your-repo/queries@main

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,11 +4,6 @@
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
 #
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
@@ -45,10 +40,7 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        config-file: ./.github/codeql/codeql-config.yml
 
     - name: Build with Maven
       run: mvn -DskipTests=true -V -ntp install

--- a/app/src/main/java/org/apache/roller/weblogger/business/themes/ThemeManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/themes/ThemeManagerImpl.java
@@ -65,7 +65,7 @@ import org.apache.roller.weblogger.util.RollerMessages;
 @com.google.inject.Singleton
 public class ThemeManagerImpl implements ThemeManager {
 
-	static FileTypeMap map = null;
+	private static final FileTypeMap map;
 	static {
 		// TODO: figure out why PNG is missing from Java MIME types
 		map = FileTypeMap.getDefaultFileTypeMap();
@@ -77,7 +77,7 @@ public class ThemeManagerImpl implements ThemeManager {
 		}
 	}
 
-	private static Log log = LogFactory.getLog(ThemeManagerImpl.class);
+	private static final Log log = LogFactory.getLog(ThemeManagerImpl.class);
 	private final Weblogger roller;
 	// directory where themes are kept
 	private String themeDir = null;
@@ -354,7 +354,7 @@ public class ThemeManagerImpl implements ThemeManager {
 				RollerMessages errors = new RollerMessages();
 				fileMgr.createThemeMediaFile(weblog, mf, errors);
 				try {
-					resource.getInputStream().close();
+					is.close();
 				} catch (IOException ex) {
 					errors.addError("error.closingStream");
 					log.debug("ERROR closing inputstream");

--- a/app/src/main/java/org/apache/roller/weblogger/ui/core/security/RollerRememberMeServices.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/core/security/RollerRememberMeServices.java
@@ -31,8 +31,8 @@ import java.security.NoSuchAlgorithmException;
 
 
 public class RollerRememberMeServices extends TokenBasedRememberMeServices {
-    private static final Log log = LogFactory.getLog(RollerRememberMeServices.class);
 
+    private static final Log log = LogFactory.getLog(RollerRememberMeServices.class);
 
     public RollerRememberMeServices(UserDetailsService userDetailsService) {
         
@@ -51,7 +51,7 @@ public class RollerRememberMeServices extends TokenBasedRememberMeServices {
 
     /**
      * Calculates the digital signature to be put in the cookie. Default value is
-     * MD5 ("username:tokenExpiryTime:password:key")
+     * SHA-512 ("username:tokenExpiryTime:password:key")
      *
      * If LDAP is enabled then a configurable dummy password is used in the calculation.
      */
@@ -70,9 +70,9 @@ public class RollerRememberMeServices extends TokenBasedRememberMeServices {
         String data = username + ":" + tokenExpiryTime + ":" + password + ":" + getKey();
         MessageDigest digest;
         try {
-            digest = MessageDigest.getInstance("MD5");
+            digest = MessageDigest.getInstance("SHA-512");
         } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("No MD5 algorithm available!");
+            throw new IllegalStateException("Required by Spec.", e);
         }
 
         return new String(Hex.encode(digest.digest(data.getBytes())));

--- a/app/src/main/java/org/apache/roller/weblogger/ui/rendering/WeblogRequestMapper.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/rendering/WeblogRequestMapper.java
@@ -46,7 +46,7 @@ import org.apache.roller.weblogger.pojos.Weblog;
  */
 public class WeblogRequestMapper implements RequestMapper {
     
-    private static Log log = LogFactory.getLog(WeblogRequestMapper.class);
+    private static final Log log = LogFactory.getLog(WeblogRequestMapper.class);
     
     private static final String PAGE_SERVLET = "/roller-ui/rendering/page";
     private static final String FEED_SERVLET = "/roller-ui/rendering/feed";
@@ -199,7 +199,7 @@ public class WeblogRequestMapper implements RequestMapper {
             // this means someone referred to a weblog index page with the 
             // shortest form of url /<weblog> or /<weblog>/<locale> and we need
             // to do a redirect to /<weblog>/ or /<weblog>/<locale>/
-            String redirectUrl = request.getRequestURI() + "/";
+            String redirectUrl = "/" + weblogHandle + "/";
             if(request.getQueryString() != null) {
                 redirectUrl += "?"+request.getQueryString();
             }

--- a/app/src/main/java/org/apache/roller/weblogger/ui/struts2/editor/FolderEdit.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/struts2/editor/FolderEdit.java
@@ -40,7 +40,7 @@ import javax.servlet.http.HttpServletResponse;
 // TODO: make this work @AllowedMethods({"execute","save"})
 public class FolderEdit extends UIAction implements ServletResponseAware {
 
-    private static Log log = LogFactory.getLog(FolderEdit.class);
+    private static final Log log = LogFactory.getLog(FolderEdit.class);
 
     // bean for managing form data
     private FolderBean bean = new FolderBean();
@@ -127,7 +127,10 @@ public class FolderEdit extends UIAction implements ServletResponseAware {
                     addMessage("folderForm.updated");
                 }
 
-                httpServletResponse.addHeader("folderId", folderId );
+                // HTTP response splitting defense
+                String sanetizedFolderID = folderId.replace("\n", "").replace("\r", "");
+
+                httpServletResponse.addHeader("folderId", sanetizedFolderID);
 
                 return SUCCESS;
 

--- a/app/src/main/java/org/apache/roller/weblogger/webservices/tagdata/TagDataServlet.java
+++ b/app/src/main/java/org/apache/roller/weblogger/webservices/tagdata/TagDataServlet.java
@@ -186,7 +186,7 @@ public class TagDataServlet extends HttpServlet {
                         0, true);
                 int frequency = stat.getCount();
                 pw.print("<atom:category term=\"" + term + "\" tagdata:frequency=\"" + frequency + "\" ");
-                pw.println("tagdata:href=\"" + viewURI + "\" />");
+                pw.println("tagdata:href=\"" + StringEscapeUtils.escapeXml10(viewURI) + "\" />");
                 if (count++ > MAX) {
                     break;
                 }
@@ -194,12 +194,12 @@ public class TagDataServlet extends HttpServlet {
             if (tags.size() > MAX) {
                 // get next URI, if site-wide then don't specify weblog
                 String nextURI = urlstrat.getWeblogTagsJsonURL(weblog, true, page + 1);
-                pw.println("<atom:link rel=\"next\" href=\"" + nextURI + "\" />");
+                pw.println("<atom:link rel=\"next\" href=\"" + StringEscapeUtils.escapeXml10(nextURI) + "\" />");
             }
             if (page > 0) {
                 // get prev URI, if site-wide then don't specify weblog
                 String prevURI = urlstrat.getWeblogTagsJsonURL(weblog, true, page - 1);
-                pw.println("<atom:link rel=\"previous\" href=\"" + prevURI + "\" />");
+                pw.println("<atom:link rel=\"previous\" href=\"" + StringEscapeUtils.escapeXml10(prevURI) + "\" />");
             }
             pw.println("</categories>");
             response.flushBuffer();

--- a/app/src/main/webapp/theme/scripts/roller.js
+++ b/app/src/main/webapp/theme/scripts/roller.js
@@ -16,11 +16,12 @@
 * directory of this distribution.
 */
 /* This function is used to set cookies */
-function setCookie(name,value,expires,path,domain,secure) {
+function setCookie(name, value, expires, path, domain, secure=true, sameSite=true) {
   document.cookie = name + "=" + escape (value) +
     ((expires) ? "; expires=" + expires.toGMTString() : "") +
     ((path) ? "; path=" + path : "") +
-    ((domain) ? "; domain=" + domain : "") + ((secure) ? "; secure" : "");
+    ((domain) ? "; domain=" + domain : "") + ((secure) ? "; secure" : "") +
+    ((sameSite) ? "; SameSite=Strict" : "");
 }
 
 /* This function is used to get cookies */


### PR DESCRIPTION
This PR closes some (~14) CodeQL alerts.

Most of them could be fixed by restructuring the code a little.

75ba795 changes the config so that JS alerts don't show up three times.

I am thinking about closing two additional alerts manually:

- [URL redirection from remote source](https://github.com/apache/roller/security/code-scanning/21?query=ref%3Arefs%2Fheads%2Fmaster) Since weblogHandle is validated [here](https://github.com/mbien/roller/blob/9e017c5535b51853b20502fe73fc821e88c681ab/app/src/main/java/org/apache/roller/weblogger/ui/rendering/WeblogRequestMapper.java#L133-L136) and used [here](https://github.com/mbien/roller/commit/b443ee4f4510f67781aab35e3c6dbefefc605060). As false positive
- [Server-side request forgery](https://github.com/apache/roller/security/code-scanning/67?query=ref%3Arefs%2Fheads%2Fmaster) Since feed URLs for planet feeds must be set by a trusted user/admin. As won't fix

bonus:
96810ea is a unrelated fix, 188e201 sets JS produced cookies to https and "SameSite" by default