### PR TITLE
"/tags/" appears twice in the cache key.

### DIFF
--- a/app/src/main/java/org/apache/roller/weblogger/ui/rendering/util/cache/SiteWideCache.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/rendering/util/cache/SiteWideCache.java
@@ -231,7 +231,6 @@ public final class SiteWideCache implements CacheHandler {
             }
             
             if("tags".equals(pageRequest.getContext())) {
-                key.append("/tags/");
                 if(pageRequest.getTags() != null && !pageRequest.getTags().isEmpty()) {
                     String[] tags = pageRequest.getTags().toArray(new String[0]);
                     Arrays.sort(tags);

--- a/app/src/main/java/org/apache/roller/weblogger/ui/rendering/util/cache/WeblogPageCache.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/rendering/util/cache/WeblogPageCache.java
@@ -203,7 +203,6 @@ public final class WeblogPageCache {
             }
             
             if("tags".equals(pageRequest.getContext())) {
-                key.append("/tags/");
                 if(pageRequest.getTags() != null && !pageRequest.getTags().isEmpty()) {
                     String[] tags = pageRequest.getTags().toArray(new String[0]);
                     Arrays.sort(tags);


### PR DESCRIPTION
Small fix. Did not impact functionality, just the way cache keys were generated.

bug introduced in  7d07a84