### PR TITLE
Inefficient Usage of Java Collections

### DIFF
--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAWeblogManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAWeblogManagerImpl.java
@@ -37,7 +37,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 
 import org.apache.roller.weblogger.business.MediaFileManager;
 import org.apache.roller.weblogger.business.UserManager;
@@ -614,7 +613,7 @@ public class JPAWeblogManagerImpl implements WeblogManager {
     @Override
     public Map<String, Long> getWeblogHandleLetterMap() throws WebloggerException {
         String lc = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        Map<String, Long> results = new TreeMap<>();
+        Map<String, Long> results = new HashMap<>();
         TypedQuery<Long> query = strategy.getNamedQuery(
                 "Weblog.getCountByHandleLike", Long.class);
         for (int i=0; i<26; i++) {

--- a/app/src/main/java/org/apache/roller/weblogger/pojos/RollerPermission.java
+++ b/app/src/main/java/org/apache/roller/weblogger/pojos/RollerPermission.java
@@ -19,6 +19,8 @@
 package org.apache.roller.weblogger.pojos;
 
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.roller.weblogger.util.Utilities;
@@ -49,14 +51,14 @@ public abstract class RollerPermission extends java.security.Permission {
     }
 
     public boolean hasAction(String action) {
-        List<String> actionList = getActionsAsList();
-        return actionList.contains(action);
+        Set<String> actionSet = new HashSet<>(getActionsAsList());
+        return actionSet.contains(action);
     }
     
     public boolean hasActions(List<String> actionsToCheck) {
-        List<String> actionList = getActionsAsList();
+        Set<String> actionSet = new HashSet<>(getActionsAsList());
         for (String actionToCheck : actionsToCheck) {
-            if (!actionList.contains(actionToCheck)) {
+            if (!actionSet.contains(actionToCheck)) {
                 return false;
             }
         }
@@ -68,9 +70,9 @@ public abstract class RollerPermission extends java.security.Permission {
      */
     public void addActions(ObjectPermission perm) {
         List<String> newActions = perm.getActionsAsList();
-        List<String> updatedActions = getActionsAsList();
+        Set<String> updatedActionSet = new HashSet<>(updatedActions);
         for (String newAction : newActions) {
-            if (!updatedActions.contains(newAction)) {
+            if (!updatedActionSet.contains(newAction)) {
                 updatedActions.add(newAction);
             }
         }
@@ -81,9 +83,9 @@ public abstract class RollerPermission extends java.security.Permission {
      * Merge actions into this permission.
      */
     public void addActions(List<String> newActions) {
-        List<String> updatedActions = getActionsAsList();
+        Set<String> updatedActionSet = new HashSet<>(updatedActions);
         for (String newAction : newActions) {
-            if (!updatedActions.contains(newAction)) {
+            if (!updatedActionSet.contains(newAction)) {
                 updatedActions.add(newAction);
             }
         }

--- a/docs/examples/scripting/bsf/src/org/apache/roller/scripting/BSFRendererFactory.java
+++ b/docs/examples/scripting/bsf/src/org/apache/roller/scripting/BSFRendererFactory.java
@@ -20,6 +20,8 @@ package org.apache.roller.scripting;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 import org.apache.roller.config.RollerConfig;
 import org.apache.roller.pojos.Template;
 import org.apache.roller.ui.rendering.Renderer;
@@ -31,13 +33,13 @@ import org.apache.roller.util.Utilities;
  */
 public class BSFRendererFactory implements RendererFactory {   
     private static String[] names = {"groovy", "jruby", "javascript"};
-    private static final List bsfLanguages; 
+    private static final Set<String> bsfLanguages; 
     static {
         String value = RollerConfig.getProperty("bsfrenderer.languageNames");
         if (value != null) {
             names = Utilities.stringToStringArray(value,",");            
         } 
-        bsfLanguages = Arrays.asList(names);
+        bsfLanguages = new HashSet<>(Arrays.asList(names));
     }        
     public Renderer getRenderer(Template template) {        
         Renderer renderer = null;


### PR DESCRIPTION
Hi,

We find that there are several inefficient usages of Java Collections:

1. The contains method is invoked upon a list object. We recommend replacing it with a HashSet.
2. There is no iteration occurring upon a TreeMap, thus the insertion order does not matter. We recommend replacing it with a HashMap.

We discovered the above inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto