### PR TITLE
maven dependency updates

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -46,19 +46,19 @@ limitations under the License.
         <commons-codec.version>1.15</commons-codec.version>
         <eclipse-link.version>2.7.9</eclipse-link.version>
         <guice.version>5.0.1</guice.version>
-        <log4j2.version>2.14.1</log4j2.version>
-        <lucene.version>8.10.1</lucene.version>
+        <log4j2.version>2.15.0</log4j2.version>
+        <lucene.version>9.0.0</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
         <maven-war.version>3.2.3</maven-war.version>
         <maven-surefire.version>2.22.2</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
         <rome.version>1.16.0</rome.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <spring.version>5.3.12</spring.version>
-        <spring.security.version>5.5.3</spring.security.version>
-        <struts.version>2.5.26</struts.version>
+        <spring.version>5.3.13</spring.version>
+        <spring.security.version>5.6.0</spring.security.version>
+        <struts.version>2.5.27</struts.version>
         <velocity.version>2.3</velocity.version>
-        <webjars.version>1.5</webjars.version>
+        <webjars.version>1.6</webjars.version>
         <ws-commons-util.version>1.0.2</ws-commons-util.version>
         <xmlrpc-version>3.1.3</xmlrpc-version>
     </properties>
@@ -246,6 +246,12 @@ limitations under the License.
         <!-- note: update head.jsp on webjar version change -->
         <dependency>
             <groupId>org.webjars</groupId>
+            <artifactId>webjars-servlet-2.x</artifactId>
+            <version>${webjars.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
             <version>3.4.1</version>
         </dependency>
@@ -265,7 +271,7 @@ limitations under the License.
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery-ui</artifactId>
-            <version>1.12.1</version>
+            <version>1.13.0</version>
         </dependency>
 
         <dependency>
@@ -282,7 +288,7 @@ limitations under the License.
 
         <dependency>
             <groupId>org.apache.lucene</groupId>
-            <artifactId>lucene-analyzers-common</artifactId>
+            <artifactId>lucene-analysis-common</artifactId>
             <scope>compile</scope>
             <version>${lucene.version}</version>
         </dependency>
@@ -520,12 +526,6 @@ limitations under the License.
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>webjars-servlet-2.x</artifactId>
-            <version>${webjars.version}</version>
         </dependency>
 
         <dependency>

--- a/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
@@ -7,8 +7,8 @@ You can override it with your own file via WEB-INF/tiles-def.xml
 
 <script src="<s:url value='/webjars/jquery/3.6.0/jquery.min.js' />"></script>
 
-<script src="<s:url value='/webjars/jquery-ui/1.12.1/jquery-ui.min.js' />"></script>
-<link href="<s:url value='/webjars/jquery-ui/1.12.1/jquery-ui.css' />" rel="stylesheet" />
+<script src="<s:url value='/webjars/jquery-ui/1.13.0/jquery-ui.min.js' />"></script>
+<link href="<s:url value='/webjars/jquery-ui/1.13.0/jquery-ui.css' />" rel="stylesheet" />
 
 <script src="<s:url value='/webjars/jquery-validation/1.19.3/jquery.validate.min.js' />"></script>
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@ limitations under the License.
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.8.1</version>
+                <version>5.8.2</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
highlights:
 - log4j 2.15.0 (fixes security vulnerability[1][2][3])
 - lucene 9 (artifact name changed)
 - spring security 5.6
 - jquery-ui 1.13 via webjar
 - other minor version bumps

[1] https://www.lunasec.io/docs/blog/log4j-zero-day/
[2] https://github.com/apache/logging-log4j2/pull/608
[3] https://github.com/advisories/GHSA-jfh8-c2jp-5v3q