### PR TITLE
Dependency update to log4j2 2.16.

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -46,7 +46,7 @@ limitations under the License.
         <commons-codec.version>1.15</commons-codec.version>
         <eclipse-link.version>2.7.9</eclipse-link.version>
         <guice.version>5.0.1</guice.version>
-        <log4j2.version>2.15.0</log4j2.version>
+        <log4j2.version>2.16.0</log4j2.version>
         <lucene.version>9.0.0</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
         <maven-war.version>3.2.3</maven-war.version>
@@ -56,7 +56,7 @@ limitations under the License.
         <slf4j.version>1.7.32</slf4j.version>
         <spring.version>5.3.13</spring.version>
         <spring.security.version>5.6.0</spring.security.version>
-        <struts.version>2.5.27</struts.version>
+        <struts.version>2.5.28</struts.version>
         <velocity.version>2.3</velocity.version>
         <webjars.version>1.6</webjars.version>
         <ws-commons-util.version>1.0.2</ws-commons-util.version>


### PR DESCRIPTION
another log4j2 version bump

- disables JNDI by default
- removes support for msg lookups

https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0