### PR TITLE
dependency updates, added bouncycastle, minor log level update.

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -41,22 +41,23 @@ limitations under the License.
         <angular.version>1.7.8</angular.version>
         <ant.version>1.10.12</ant.version>
         <asm.version>9.2</asm.version>
+        <bouncycastle.version>1.70</bouncycastle.version>
         <commons-validator.version>1.7</commons-validator.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-codec.version>1.15</commons-codec.version>
         <eclipse-link.version>2.7.10</eclipse-link.version>
-        <guice.version>5.0.1</guice.version>
-        <log4j2.version>2.17.1</log4j2.version>
-        <lucene.version>9.0.0</lucene.version>
+        <guice.version>5.1.0</guice.version>
+        <log4j2.version>2.17.2</log4j2.version>
+        <lucene.version>9.1.0</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
         <maven-war.version>3.2.3</maven-war.version>
         <maven-surefire.version>2.22.2</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
-        <rome.version>1.17.0</rome.version>
-        <slf4j.version>1.7.32</slf4j.version>
-        <spring.version>5.3.14</spring.version>
-        <spring.security.version>5.6.1</spring.security.version>
-        <struts.version>2.5.28.2</struts.version>
+        <rome.version>1.18.0</rome.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <spring.version>5.3.18</spring.version>
+        <spring.security.version>5.6.2</spring.security.version>
+        <struts.version>2.5.29</struts.version>
         <velocity.version>2.3</velocity.version>
         <webjars.version>1.6</webjars.version>
         <ws-commons-util.version>1.0.2</ws-commons-util.version>
@@ -533,6 +534,12 @@ limitations under the License.
             <artifactId>oauth-provider</artifactId>
             <scope>compile</scope>
             <version>${oauth-core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${bouncycastle.version}</version>
         </dependency>
 
         <!-- Test deps -->

--- a/app/src/main/java/org/apache/roller/weblogger/business/startup/DatabaseInstaller.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/startup/DatabaseInstaller.java
@@ -204,8 +204,8 @@ public class DatabaseInstaller {
         int myVersion = parseVersionString(version);
         int dbversion = getDatabaseVersion();
 
-        log.debug("Database version = "+dbversion);
-        log.debug("Desired version = "+myVersion);
+        log.info("Database version = "+dbversion);
+        log.info("Desired version = "+myVersion);
 
         Connection con = null;
         try {

--- a/app/src/main/java/org/apache/roller/weblogger/ui/core/RollerContext.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/core/RollerContext.java
@@ -50,7 +50,9 @@ import org.apache.roller.weblogger.util.cache.CacheManager;
 import org.apache.velocity.runtime.RuntimeSingleton;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
@@ -300,9 +302,9 @@ public class RollerContext extends ContextLoaderListener
         // supported encoders
         encoders.put("bcrypt", new BCryptPasswordEncoder());
         encoders.put("pbkdf2", new Pbkdf2PasswordEncoder());
-        // requires bouncy castle impl
-//        encoders.put("scrypt", new SCryptPasswordEncoder());
-//        encoders.put("argon2", new Argon2PasswordEncoder());
+        // provided by bouncy castle dependency
+        encoders.put("scrypt", new SCryptPasswordEncoder());
+        encoders.put("argon2", new Argon2PasswordEncoder());
 
         // just for testing
         encoders.put("noop", org.springframework.security.crypto.password.NoOpPasswordEncoder.getInstance());


### PR DESCRIPTION
 - **notable dependency update: spring 5.3.18** with **security** fixes for "[spring4shell](https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751)"
 - bouncy castle was added so that the popular Argon2 pw encoder can be used

available (non legacy) encoders: bcrypt, pbkdf2, scrypt, argon2

**Reminder how to change the encoder:**
`passwds.encryption.algorithm=argon2`, default remains `pbkdf2`
automatic migration happens on next pw change

**If one of the (very, very) old legacy codecs is still in use, roller will need a hint for migration**
`passwds.encryption.lazyUpgradeFrom=`
possible options: `plaintext, MD5, SHA-1` can be left empty if the db doesn't contain any legacy encoded pws

@snoopdave might be a good time for another point release :)