### PR TITLE
Upgrade to Jakarta Eclipselink + other minor dependency bumps

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -40,7 +40,7 @@ limitations under the License.
         <jstl.version>1.2</jstl.version>
         <angular.version>1.7.8</angular.version>
         <ant.version>1.10.12</ant.version>
-        <asm.version>9.2</asm.version>
+        <asm.version>9.3</asm.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <commons-validator.version>1.7</commons-validator.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
@@ -48,15 +48,15 @@ limitations under the License.
         <eclipse-link.version>3.0.2</eclipse-link.version>
         <guice.version>5.1.0</guice.version>
         <log4j2.version>2.17.2</log4j2.version>
-        <lucene.version>9.1.0</lucene.version>
+        <lucene.version>9.2.0</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
         <maven-war.version>3.2.3</maven-war.version>
         <maven-surefire.version>2.22.2</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
         <rome.version>1.18.0</rome.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <spring.version>5.3.18</spring.version>
-        <spring.security.version>5.6.2</spring.security.version>
+        <spring.version>5.3.20</spring.version>
+        <spring.security.version>5.7.1</spring.security.version>
         <struts.version>2.5.29</struts.version>
         <velocity.version>2.3</velocity.version>
         <webjars.version>1.6</webjars.version>
@@ -272,7 +272,7 @@ limitations under the License.
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery-ui</artifactId>
-            <version>1.13.0</version>
+            <version>1.13.1</version>
         </dependency>
 
         <dependency>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -45,7 +45,7 @@ limitations under the License.
         <commons-validator.version>1.7</commons-validator.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-codec.version>1.15</commons-codec.version>
-        <eclipse-link.version>2.7.10</eclipse-link.version>
+        <eclipse-link.version>3.0.2</eclipse-link.version>
         <guice.version>5.1.0</guice.version>
         <log4j2.version>2.17.2</log4j2.version>
         <lucene.version>9.1.0</lucene.version>

--- a/app/src/main/java/org/apache/roller/planet/business/jpa/JPAPlanetManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/planet/business/jpa/JPAPlanetManagerImpl.java
@@ -23,9 +23,9 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import javax.persistence.NoResultException;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -49,7 +49,7 @@ import org.apache.roller.weblogger.business.jpa.JPAPersistenceStrategy;
 @com.google.inject.Singleton
 public class JPAPlanetManagerImpl extends AbstractManagerImpl implements PlanetManager {
     
-    private static Log log = LogFactory.getLog(JPAPlanetManagerImpl.class);
+    private static final Log log = LogFactory.getLog(JPAPlanetManagerImpl.class);
     
     /** The strategy for this manager. */
     private final JPAPersistenceStrategy strategy;

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAAutoPingManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAAutoPingManagerImpl.java
@@ -29,8 +29,8 @@ import org.apache.roller.weblogger.pojos.WeblogEntry;
 import org.apache.roller.weblogger.pojos.Weblog;
 import java.util.Collection;
 import java.util.List;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 import org.apache.roller.weblogger.business.Weblogger;
 
 /*
@@ -47,7 +47,7 @@ public class JPAAutoPingManagerImpl implements AutoPingManager {
     /**
      * The logger instance for this class.
      */
-    private static Log logger = LogFactory.getFactory().getInstance(JPAAutoPingManagerImpl.class);
+    private static final Log logger = LogFactory.getFactory().getInstance(JPAAutoPingManagerImpl.class);
 
     /**
      * Creates a new instance of JPAAutoPingManagerImpl

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPABookmarkManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPABookmarkManagerImpl.java
@@ -20,8 +20,8 @@ package org.apache.roller.weblogger.business.jpa;
 
 import java.io.StringReader;
 import java.util.List;
-import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -52,8 +52,7 @@ public class JPABookmarkManagerImpl implements BookmarkManager {
     /**
      * The logger instance for this class.
      */
-    private static Log log = LogFactory
-            .getFactory().getInstance(JPABookmarkManagerImpl.class);
+    private static final Log log = LogFactory.getFactory().getInstance(JPABookmarkManagerImpl.class);
 
     /**
      * Creates a new instance of JPABookmarkManagerImpl

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAMediaFileManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAMediaFileManagerImpl.java
@@ -37,8 +37,8 @@ import java.util.Properties;
 import java.util.Set;
 
 import javax.imageio.ImageIO;
-import javax.persistence.NoResultException;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAOAuthManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAOAuthManagerImpl.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.Date;
 import java.util.UUID;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 import net.oauth.OAuthAccessor;
 import net.oauth.OAuthConsumer;
 import net.oauth.OAuthException;
@@ -52,8 +52,7 @@ public class JPAOAuthManagerImpl implements OAuthManager {
     /**
      * The logger instance for this class.
      */
-    private static Log log = LogFactory
-            .getFactory().getInstance(JPAOAuthManagerImpl.class);
+    private static final Log log = LogFactory.getFactory().getInstance(JPAOAuthManagerImpl.class);
 
 
     @com.google.inject.Inject

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAPersistenceStrategy.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAPersistenceStrategy.java
@@ -25,15 +25,15 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.roller.weblogger.WebloggerException;
 import org.apache.roller.weblogger.config.WebloggerConfig;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.EntityManager;
-import javax.persistence.FlushModeType;
-import javax.persistence.Persistence;
-import javax.persistence.PersistenceException;
-import javax.persistence.Query;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.Persistence;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.Query;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 
 import org.apache.roller.weblogger.business.DatabaseProvider;
 
@@ -81,7 +81,7 @@ public class JPAPersistenceStrategy {
             Enumeration<Object> keys = WebloggerConfig.keys();
             while (keys.hasMoreElements()) {
                 String key = (String) keys.nextElement();
-                if (       key.startsWith("javax.persistence.") 
+                if (       key.startsWith("jakarta.persistence.")
                         || key.startsWith("openjpa.")
                         || key.startsWith("eclipselink.")
                         || key.startsWith("hibernate.")) {
@@ -92,12 +92,12 @@ public class JPAPersistenceStrategy {
             }
 
             if (dbProvider.getType() == DatabaseProvider.ConfigurationType.JNDI_NAME) {
-                emfProps.setProperty("javax.persistence.nonJtaDataSource", dbProvider.getFullJndiName());
+                emfProps.setProperty("jakarta.persistence.nonJtaDataSource", dbProvider.getFullJndiName());
             } else {
-                emfProps.setProperty("javax.persistence.jdbc.driver", dbProvider.getJdbcDriverClass());
-                emfProps.setProperty("javax.persistence.jdbc.url", dbProvider.getJdbcConnectionURL());
-                emfProps.setProperty("javax.persistence.jdbc.user", dbProvider.getJdbcUsername());
-                emfProps.setProperty("javax.persistence.jdbc.password", dbProvider.getJdbcPassword());
+                emfProps.setProperty("jakarta.persistence.jdbc.driver", dbProvider.getJdbcDriverClass());
+                emfProps.setProperty("jakarta.persistence.jdbc.url", dbProvider.getJdbcConnectionURL());
+                emfProps.setProperty("jakarta.persistence.jdbc.user", dbProvider.getJdbcUsername());
+                emfProps.setProperty("jakarta.persistence.jdbc.password", dbProvider.getJdbcPassword());
             }
 
             try {

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAPingQueueManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAPingQueueManagerImpl.java
@@ -20,7 +20,7 @@ package org.apache.roller.weblogger.business.jpa;
 
 import java.sql.Timestamp;
 import java.util.List;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.TypedQuery;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -38,8 +38,7 @@ import org.apache.roller.weblogger.pojos.PingQueueEntry;
 @com.google.inject.Singleton
 public class JPAPingQueueManagerImpl implements PingQueueManager {
 
-    private static Log log = LogFactory.getLog(
-        JPAPingQueueManagerImpl.class);
+    private static final Log log = LogFactory.getLog(JPAPingQueueManagerImpl.class);
 
     /** The strategy for this manager. */
     private final JPAPersistenceStrategy strategy;

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAPingTargetManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAPingTargetManagerImpl.java
@@ -23,8 +23,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.List;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 import org.apache.roller.weblogger.WebloggerException;
 import org.apache.roller.weblogger.business.pings.PingTargetManager;

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAThreadManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAThreadManagerImpl.java
@@ -20,9 +20,9 @@ package org.apache.roller.weblogger.business.jpa;
 
 import java.sql.Timestamp;
 import java.util.Date;
-import javax.persistence.NoResultException;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.roller.util.DateUtil;

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAUserManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAUserManagerImpl.java
@@ -19,7 +19,6 @@
 package org.apache.roller.weblogger.business.jpa;
 
 import java.sql.Timestamp;
-import javax.persistence.NoResultException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -33,7 +32,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
 import org.apache.roller.weblogger.config.WebloggerConfig;
 import org.apache.roller.weblogger.pojos.GlobalPermission;
 import org.apache.roller.weblogger.pojos.RollerPermission;
@@ -45,12 +45,12 @@ import org.apache.roller.weblogger.pojos.WeblogPermission;
 
 @com.google.inject.Singleton
 public class JPAUserManagerImpl implements UserManager {
-    private static Log log = LogFactory.getLog(JPAUserManagerImpl.class);
+    private static final Log log = LogFactory.getLog(JPAUserManagerImpl.class);
 
     private final JPAPersistenceStrategy strategy;
     
     // cached mapping of userNames -> userIds
-    private Map<String, String> userNameToIdMap = Collections.synchronizedMap(new HashMap<String, String>());
+    private final Map<String, String> userNameToIdMap = Collections.synchronizedMap(new HashMap<>());
     
 
     @com.google.inject.Inject

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAWeblogEntryManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAWeblogEntryManagerImpl.java
@@ -21,9 +21,9 @@ package org.apache.roller.weblogger.business.jpa;
 import java.util.*;
 import java.text.SimpleDateFormat;
 import java.sql.Timestamp;
-import javax.persistence.NoResultException;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAWeblogManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPAWeblogManagerImpl.java
@@ -26,9 +26,9 @@ import org.apache.roller.weblogger.business.pings.AutoPingManager;
 import org.apache.roller.weblogger.business.pings.PingTargetManager;
 import org.apache.roller.weblogger.config.WebloggerConfig;
 
-import javax.persistence.NoResultException;
-import javax.persistence.Query;
-import javax.persistence.TypedQuery;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -81,7 +81,7 @@ public class JPAWeblogManagerImpl implements WeblogManager {
     private final JPAPersistenceStrategy strategy;
     
     // cached mapping of weblogHandles -> weblogIds
-    private final Map<String,String> weblogHandleToIdMap = Collections.synchronizedMap(new HashMap<String,String>());
+    private final Map<String, String> weblogHandleToIdMap = Collections.synchronizedMap(new HashMap<>());
 
     @com.google.inject.Inject
     protected JPAWeblogManagerImpl(Weblogger roller, JPAPersistenceStrategy strat) {

--- a/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
@@ -7,8 +7,8 @@ You can override it with your own file via WEB-INF/tiles-def.xml
 
 <script src="<s:url value='/webjars/jquery/3.6.0/jquery.min.js' />"></script>
 
-<script src="<s:url value='/webjars/jquery-ui/1.13.0/jquery-ui.min.js' />"></script>
-<link href="<s:url value='/webjars/jquery-ui/1.13.0/jquery-ui.css' />" rel="stylesheet" />
+<script src="<s:url value='/webjars/jquery-ui/1.13.1/jquery-ui.min.js' />"></script>
+<link href="<s:url value='/webjars/jquery-ui/1.13.1/jquery-ui.css' />" rel="stylesheet" />
 
 <script src="<s:url value='/webjars/jquery-validation/1.19.3/jquery.validate.min.js' />"></script>
 


### PR DESCRIPTION
 - jakarta namespace update allows roller to use eclipse link 3.x.
 - minor dependency updates (asm, lucene, spring, jquery-ui webjar)

struts wasn't updated due to some breaking changes, see:
 - https://github.com/apache/struts/pull/496
 - https://cwiki.apache.org/confluence/display/WW/Version+Notes+2.5.30