### PR TITLE
minor dependency updates + test-summary workflow action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,17 +30,20 @@ jobs:
 
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'zulu'
   
       - name: Checkout Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          submodules: false
   
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -49,4 +52,4 @@ jobs:
         run: mvn -DskipTests=true -V -ntp install
   
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,6 @@
 
 name: Apache Roller
 
-# junit report action
-# https://github.com/marketplace/actions/junit-report-action
-
 on:
   push:
     branches: [master]
@@ -30,21 +27,30 @@ jobs:
   build-test:
     name: Build+Test on Linux/JDK ${{ matrix.java }} 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11', '17', '18' ]
+        java: [ '11', '17', '20' ]
 
     steps:
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }} 
           distribution: 'zulu'
 
+      - name: Setup Xvfb
+        run: |
+          echo "DISPLAY=:99.0" >> $GITHUB_ENV
+          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+
       - name: Checkout Project
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          submodules: false
 
       - name: Build Roller and run JUnit Tests
         run: mvn -V -ntp install
@@ -52,23 +58,19 @@ jobs:
       - name: Run Integration Tests
         run: |
           cd it-selenium
-          bash -c "wget -c https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz -O - | tar -xz"
-          mvn -V -ntp install
+          mvn -V -ntp -Dwebdriver.gecko.driver=$GECKOWEBDRIVER/geckodriver install
 
-# TODO: needs submodule workaround since apache does not allow third party actions anymore
-#      - name: Publish JUnit Report
-#        uses: mikepenz/action-junit-report@v3
-#        if: always()
-#        with:
-#          check_name: JUnit Reports for Linux/JDK ${{ matrix.java }} 
-#          report_paths: 'app/target/surefire-reports/TEST-*.xml'
-#
-#      - name: Publish IT Report
-#        uses: mikepenz/action-junit-report@v3
-#        if: always()
-#        with:
-#          check_name: IT Reports for Linux/JDK ${{ matrix.java }} 
-#          report_paths: 'it-selenium/target/failsafe-reports/TEST-*.xml'
+      - name: Publish JUnit Report
+        uses: test-summary/action@v2
+        if: always()
+        with:
+          paths: "app/target/surefire-reports/TEST-*.xml"
+
+      - name: Publish IT Report
+        uses: test-summary/action@v2
+        if: always()
+        with:
+          paths: "it-selenium/target/failsafe-reports/TEST-*.xml"
       
       # only on integration and only once in this matrix
       - name: Upload Dev Build on Integration

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -39,24 +39,24 @@ limitations under the License.
         <java-mail.version>1.4.7</java-mail.version>
         <jstl.version>1.2</jstl.version>
         <angular.version>1.7.8</angular.version>
-        <ant.version>1.10.12</ant.version>
-        <asm.version>9.3</asm.version>
+        <ant.version>1.10.13</ant.version>
+        <asm.version>9.4</asm.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <commons-validator.version>1.7</commons-validator.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-codec.version>1.15</commons-codec.version>
-        <eclipse-link.version>3.0.2</eclipse-link.version>
+        <eclipse-link.version>4.0.1</eclipse-link.version>
         <guice.version>5.1.0</guice.version>
-        <log4j2.version>2.17.2</log4j2.version>
-        <lucene.version>9.2.0</lucene.version>
+        <log4j2.version>2.20.0</log4j2.version>
+        <lucene.version>9.5.0</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
-        <maven-war.version>3.2.3</maven-war.version>
+        <maven-war.version>3.3.2</maven-war.version>
         <maven-surefire.version>2.22.2</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
-        <rome.version>1.18.0</rome.version>
+        <rome.version>1.19.0</rome.version> <!-- locked in place since next version removes popono -->
         <slf4j.version>1.7.36</slf4j.version>
-        <spring.version>5.3.20</spring.version>
-        <spring.security.version>5.7.1</spring.security.version>
+        <spring.version>5.3.25</spring.version>
+        <spring.security.version>5.8.2</spring.security.version>
         <struts.version>2.5.29</struts.version>
         <velocity.version>2.3</velocity.version>
         <webjars.version>1.6</webjars.version>
@@ -266,13 +266,13 @@ limitations under the License.
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery-ui</artifactId>
-            <version>1.13.1</version>
+            <version>1.13.2</version>
         </dependency>
 
         <dependency>
@@ -284,7 +284,7 @@ limitations under the License.
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery-validation</artifactId>
-            <version>1.19.3</version>
+            <version>1.19.5</version>
         </dependency>
 
         <dependency>
@@ -365,7 +365,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
+            <version>1.10.0</version>
          </dependency>
 
         <dependency>
@@ -812,7 +812,7 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>

--- a/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
@@ -5,12 +5,12 @@ You can override it with your own file via WEB-INF/tiles-def.xml
 
 <%@ include file="/WEB-INF/jsps/taglibs-struts2.jsp" %>
 
-<script src="<s:url value='/webjars/jquery/3.6.0/jquery.min.js' />"></script>
+<script src="<s:url value='/webjars/jquery/3.6.1/jquery.min.js' />"></script>
 
-<script src="<s:url value='/webjars/jquery-ui/1.13.1/jquery-ui.min.js' />"></script>
-<link href="<s:url value='/webjars/jquery-ui/1.13.1/jquery-ui.css' />" rel="stylesheet" />
+<script src="<s:url value='/webjars/jquery-ui/1.13.2/jquery-ui.min.js' />"></script>
+<link href="<s:url value='/webjars/jquery-ui/1.13.2/jquery-ui.css' />" rel="stylesheet" />
 
-<script src="<s:url value='/webjars/jquery-validation/1.19.3/jquery.validate.min.js' />"></script>
+<script src="<s:url value='/webjars/jquery-validation/1.19.5/jquery.validate.min.js' />"></script>
 
 <link href="<s:url value='/webjars/bootstrap/3.4.1/css/bootstrap.min.css' />" rel="stylesheet" />
 <link href="<s:url value='/webjars/bootstrap/3.4.1/css/bootstrap-theme.min.css' />" rel="stylesheet" />

--- a/app/src/test/java/org/apache/roller/weblogger/business/CommentTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/CommentTest.java
@@ -28,6 +28,8 @@ import org.apache.roller.weblogger.pojos.WeblogEntryComment.ApprovalStatus;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -48,6 +50,7 @@ public class CommentTest  {
     /**
      * All tests in this suite require a user, weblog, and an entry.
      */
+    @BeforeEach
     public void setUp() throws Exception {
         
         // setup weblogger
@@ -63,7 +66,8 @@ public class CommentTest  {
             throw new Exception("Test setup failed", ex);
         }
     }
-    
+
+    @AfterEach
     public void tearDown() throws Exception {
         
         try {

--- a/app/src/test/java/org/apache/roller/weblogger/business/MediaFileTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/MediaFileTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.sql.Timestamp;
 import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -47,11 +48,9 @@ public class MediaFileTest  {
     public MediaFileTest() {
     }
 
+    @BeforeEach
     public void setUp() throws Exception {
         TestUtils.setupWeblogger();
-    }
-
-    public void tearDown() throws Exception {
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ limitations under the License.
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <derby.version>10.11.1.1</derby.version>
         <jaxb.version>2.3.1</jaxb.version>
-        <jetty.version>10.0.5</jetty.version>
+        <jetty.version>10.0.14</jetty.version>
         <roller.version>6.1.2-SNAPSHOT</roller.version>
     </properties>
 
@@ -59,7 +59,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.11.0</version>
                     <configuration>
                         <release>11</release>
                         <fork>true</fork>
@@ -90,7 +90,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.8.1</version>
+                    <version>2.15.0</version>
                     <configuration>
                         <rulesUri>file:version-rules.xml</rulesUri>
                     </configuration>
@@ -113,7 +113,7 @@ limitations under the License.
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.8.2</version>
+                <version>5.9.2</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
- the test-summary action has [been allowed by infra](https://issues.apache.org/jira/browse/INFRA-23445) for CI use and works fairly well for the NetBeans project where we use it since then. The only annoyance is that it ignores errors, while it will pick up junit failures, but a PR is pending for that.
It writes test reports directly to the workflow summary page (not to checks, which felt like a workaround anyway).
- test runners should have geckodriver preinstalled, lets see if we can simply set a path to it.
- enabled xserver for headful integration testing
- minor maven dependency updates
- gh action version updates since they cause warnings
- bump JDK 18 to ~19~ 20 in the test matrix

tested locally.. lets see if everything builds with CI too