### PR TITLE
Start Derby from Java so tests can run without Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Roller is made up of the following Maven projects:
 * _roller-project_:         Top level project
 * _app_:                    Roller Weblogger webapp, JSP pages, Velocity templates
 * _assembly-release_:       Used to create official distributions of Roller
-* _docs_:                   Roller documentation in ODT format
+* _docs_:                   Roller documentation in ASCII Doc format
 * _it-selenium_:            Integrated browser tests for Roller using Selenium
 
 ## Documentation

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -24,7 +24,7 @@ limitations under the License.
     <parent>
         <groupId>org.apache.roller</groupId>
         <artifactId>roller-project</artifactId>
-        <version>6.1.1</version>
+        <version>6.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -629,7 +629,7 @@ limitations under the License.
                 </dependencies>
             </plugin>
 
-            <!-- Activates the Derby database for unit tests and mvn jetty:run -->
+            <!-- Activates the Derby database for unit tests and mvn jetty:run
             <plugin>
                 <groupId>com.btmatthews.maven.plugins.inmemdb</groupId>
                 <artifactId>inmemdb-maven-plugin</artifactId>
@@ -667,6 +667,7 @@ limitations under the License.
                 </executions>
 
             </plugin>
+            -->
 
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/app/src/main/java/org/apache/roller/weblogger/business/startup/SQLScriptRunner.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/startup/SQLScriptRunner.java
@@ -118,10 +118,8 @@ public class SQLScriptRunner {
             try {
                 Statement stmt = con.createStatement();
                 stmt.executeUpdate(command);
-                if (!con.getAutoCommit()) {
-                    con.commit();
-                }
-                
+                con.commit();
+
                 // on success, echo command to messages
                 successMessage(command);
                 

--- a/app/src/main/java/org/apache/roller/weblogger/business/startup/SQLScriptRunner.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/startup/SQLScriptRunner.java
@@ -118,7 +118,9 @@ public class SQLScriptRunner {
             try {
                 Statement stmt = con.createStatement();
                 stmt.executeUpdate(command);
-                con.commit();
+                if (!con.getAutoCommit()) {
+                    con.commit();
+                }
 
                 // on success, echo command to messages
                 successMessage(command);

--- a/app/src/main/resources/sql/droptables.sql
+++ b/app/src/main/resources/sql/droptables.sql
@@ -38,6 +38,9 @@ drop table roller_mediafiletag;
 drop table roller_mediafile;
 drop table roller_mediafiledir;
 
+-- oauth tables
+drop table roller_oauthconsumer;
+drop table roller_oauthaccessor;
 
 -- core services tables
 drop table roller_hitcounts;
@@ -52,10 +55,6 @@ drop table custom_template_rendition;
 
 -- core platform tables
 drop table roller_permission;
-drop table weblog;
 drop table userrole;
 drop table roller_user;
-
--- oauth tables
-drop table roller_oauthconsumer;
-drop table roller_oauthaccessor;
+drop table weblog;

--- a/app/src/test/java/org/apache/roller/util/DerbyManager.java
+++ b/app/src/test/java/org/apache/roller/util/DerbyManager.java
@@ -51,20 +51,15 @@ public class DerbyManager {
                 //System.setProperty("derby.drda.logConnections","true");
                 NetworkServerControl server = new NetworkServerControl();
                 server.start(new PrintWriter(System.out));
+                
                 try {Thread.sleep(2000);} catch (Exception ignored) {}
                 System.out.println("Runtime Info: " + server.getRuntimeInfo());
-                //System.out.println("System Info:  " + server.getSysinfo());
 
                 Class.forName("org.apache.derby.jdbc.ClientDriver");
                 Connection conn = DriverManager.getConnection(
                     "jdbc:derby://localhost:" + port + "/rollerdb;create=true","APP", "APP");
 
-                //Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
-                //Connection conn = DriverManager.getConnection(
-                //"jdbc:derby:rollerdb;create=true","APP", "APP");
-
                 // create roller tables
-
                 SQLScriptRunner runner1 = new SQLScriptRunner(
                     databaseScriptsDir + File.separator + "droptables.sql");
                 runner1.runScript(conn, false);
@@ -85,21 +80,13 @@ public class DerbyManager {
             e.printStackTrace();
             throw new Exception("ERROR starting Derby");
         }
-
     }
 
     public void stopDerby() throws Exception {
         try {
                 Class.forName("org.apache.derby.jdbc.ClientDriver");
-
-                String driverURL =
-                    "jdbc:derby://localhost:" + port + "/rollerdb";
-                Connection conn =
-                    DriverManager.getConnection(driverURL,"APP", "APP");
-
-                //Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
-                //Connection conn = DriverManager.getConnection(
-                //"jdbc:derby:rollerdb;create=true","APP", "APP");
+                String driverURL = "jdbc:derby://localhost:" + port + "/rollerdb";
+                Connection conn = DriverManager.getConnection(driverURL,"APP", "APP");
 
                 // drop Roller tables
                 SQLScriptRunner runner = new SQLScriptRunner(
@@ -124,17 +111,6 @@ public class DerbyManager {
                 //System.setProperty("derby.drda.logConnections","true");
                 NetworkServerControl server = new NetworkServerControl();
                 server.shutdown();
-
-                //try {
-                //    while (true) {
-                //       server.ping();
-                //    }
-                //} catch (Exception expected) {}
-
-                // Embedded Derby
-                //DriverManager.getConnection("jdbc:derby:;shutdown=true");
-
-                //try {Thread.sleep(2000);} catch (Exception ignored) {}
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/app/src/test/java/org/apache/roller/util/DerbyManager.java
+++ b/app/src/test/java/org/apache/roller/util/DerbyManager.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  The ASF licenses this file to You
+ * under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.  For additional information regarding
+ * copyright in this work, please see the NOTICE file in the top level
+ * directory of this distribution.
+ */
+package org.apache.roller.util;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+
+import org.apache.derby.drda.NetworkServerControl;
+import org.apache.roller.weblogger.business.startup.SQLScriptRunner;
+
+
+public class DerbyManager {
+    private final String databaseDir;
+    private final String databaseScriptsDir;
+    private final int port;
+
+    public DerbyManager(String databaseDir, String databaseScriptsDir, int port) {
+        this.databaseDir = databaseDir;
+        this.databaseScriptsDir = databaseScriptsDir;
+        this.port = port;
+    }
+
+    public void startDerby() throws Exception {
+        try {
+                System.out.println("==============");
+                System.out.println("Starting Derby");
+                System.out.println("==============");
+
+                System.setProperty("derby.system.home", databaseDir);
+
+                System.setProperty("derby.drda.portNumber", ""+port);
+                System.setProperty("derby.drda.host", "localhost");
+                System.setProperty("derby.drda.maxThreads","10");
+                //System.setProperty("derby.drda.logConnections","true");
+                NetworkServerControl server = new NetworkServerControl();
+                server.start(new PrintWriter(System.out));
+                try {Thread.sleep(2000);} catch (Exception ignored) {}
+                System.out.println("Runtime Info: " + server.getRuntimeInfo());
+                //System.out.println("System Info:  " + server.getSysinfo());
+
+                Class.forName("org.apache.derby.jdbc.ClientDriver");
+                Connection conn = DriverManager.getConnection(
+                    "jdbc:derby://localhost:" + port + "/rollerdb;create=true","APP", "APP");
+
+                //Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+                //Connection conn = DriverManager.getConnection(
+                //"jdbc:derby:rollerdb;create=true","APP", "APP");
+
+                // create roller tables
+
+                SQLScriptRunner runner1 = new SQLScriptRunner(
+                    databaseScriptsDir + File.separator + "droptables.sql");
+                runner1.runScript(conn, false);
+                runner1.runScript(conn, false); // not sure why this is necessary
+
+                SQLScriptRunner runner = new SQLScriptRunner(
+                    databaseScriptsDir + File.separator + "derby" + File.separator + "createdb.sql");
+                try {
+                    runner.runScript(conn, true);
+                } catch (Exception ignored) {
+                    for (String message : runner.getMessages()) {
+                        System.out.println(message);
+                    }
+                    ignored.printStackTrace();
+                }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new Exception("ERROR starting Derby");
+        }
+
+    }
+
+    public void stopDerby() throws Exception {
+        try {
+                Class.forName("org.apache.derby.jdbc.ClientDriver");
+
+                String driverURL =
+                    "jdbc:derby://localhost:" + port + "/rollerdb";
+                Connection conn =
+                    DriverManager.getConnection(driverURL,"APP", "APP");
+
+                //Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
+                //Connection conn = DriverManager.getConnection(
+                //"jdbc:derby:rollerdb;create=true","APP", "APP");
+
+                // drop Roller tables
+                SQLScriptRunner runner = new SQLScriptRunner(
+                    databaseScriptsDir
+                        + File.separator + "droptables.sql");
+                runner.runScript(conn, false);
+
+                System.out.println("==============");
+                System.out.println("Stopping Derby");
+                System.out.println("==============");
+
+                try {
+                    DriverManager.getConnection(driverURL + ";shutdown=true");
+                } catch (Exception ignored) {}
+
+                System.setProperty("derby.system.home", databaseDir);
+
+                // Network Derby
+                System.setProperty("derby.drda.portNumber", ""+port);
+                System.setProperty("derby.drda.host", "localhost");
+                System.setProperty("derby.drda.maxThreads","10");
+                //System.setProperty("derby.drda.logConnections","true");
+                NetworkServerControl server = new NetworkServerControl();
+                server.shutdown();
+
+                //try {
+                //    while (true) {
+                //       server.ping();
+                //    }
+                //} catch (Exception expected) {}
+
+                // Embedded Derby
+                //DriverManager.getConnection("jdbc:derby:;shutdown=true");
+
+                //try {Thread.sleep(2000);} catch (Exception ignored) {}
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new Exception(e.getMessage());
+        }
+    }
+}

--- a/app/src/test/java/org/apache/roller/weblogger/TestUtils.java
+++ b/app/src/test/java/org/apache/roller/weblogger/TestUtils.java
@@ -57,6 +57,7 @@ import org.apache.roller.weblogger.pojos.WeblogEntryComment;
 import org.apache.roller.weblogger.pojos.WeblogEntryComment.ApprovalStatus;
 import org.apache.roller.weblogger.pojos.WeblogHitCount;
 import org.apache.roller.weblogger.pojos.WeblogPermission;
+import org.apache.roller.util.DerbyManager;
 
 /**
  * Utility class for unit test classes.
@@ -66,9 +67,17 @@ public final class TestUtils {
     // Username prefix we are using (simplifies local testing)
     public static final String JUNIT_PREFIX = "junit_";
 
+    private static DerbyManager derbyManager = null;
+
     public static void setupWeblogger() throws Exception {
 
         if (!WebloggerFactory.isBootstrapped()) {
+            synchronized (TestUtils.class) {
+                if (derbyManager == null) {
+                    derbyManager = new DerbyManager("./target/testdb", "./target/dbscripts", 4224);
+                    derbyManager.startDerby();
+                }
+            }
 
             // do core services preparation
             WebloggerStartup.prepare();
@@ -105,6 +114,8 @@ public final class TestUtils {
 
         // trigger shutdown
         WebloggerFactory.getWeblogger().shutdown();
+
+        derbyManager.stopDerby();
     }
 
     /**

--- a/app/src/test/resources/roller-custom.properties
+++ b/app/src/test/resources/roller-custom.properties
@@ -1,7 +1,7 @@
 
 database.configurationType=jdbc
 database.jdbc.driverClass=org.apache.derby.jdbc.ClientDriver
-database.jdbc.connectionURL=jdbc:derby://localhost:4224/memory:rollerdb
+database.jdbc.connectionURL=jdbc:derby://localhost:4224/rollerdb
 database.jdbc.username=APP
 database.jdbc.password=APP
 

--- a/assembly-release/pom.xml
+++ b/assembly-release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.roller</groupId>
         <artifactId>roller-project</artifactId>
-        <version>6.1.1</version>
+        <version>6.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assembly-release/sign-release.sh
+++ b/assembly-release/sign-release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-export rcstring="-rc1"
-export vstring="6.1.1"
+export rcstring=""
+export vstring="6.1.2-SNAPSHOT"
 
 # for rc releases we rename the release files
 if [ rcstring != "" ]; then

--- a/it-selenium/pom.xml
+++ b/it-selenium/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.roller</groupId>
         <artifactId>roller-project</artifactId>
-        <version>6.1.1</version>
+        <version>6.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ limitations under the License.
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.roller</groupId>
     <artifactId>roller-project</artifactId>
-    <version>6.1.1</version>
+    <version>6.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Roller</name>
@@ -45,7 +45,7 @@ limitations under the License.
         <derby.version>10.11.1.1</derby.version>
         <jaxb.version>2.3.1</jaxb.version>
         <jetty.version>10.0.5</jetty.version>
-        <roller.version>6.1.1</roller.version>
+        <roller.version>6.1.2-SNAPSHOT</roller.version>
     </properties>
 
     <modules>
@@ -86,15 +86,6 @@ limitations under the License.
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
                     <version>${jetty.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>com.btmatthews.maven.plugins.inmemdb</groupId>
-                    <artifactId>inmemdb-maven-plugin</artifactId>
-                    <version>1.4.3</version>
-                    <configuration>
-                        <monitorKey>inmemdb</monitorKey>
-                        <monitorPort>11527</monitorPort>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This PR removes the Maven Plugin that was used to start/stop Derby and re-introduces some old code that starts Derby via Java and creates the Roller schema before tests run and stops Derby after they complete.

Also, changes version to `6.1.2-SNAPSHOT`