### PR TITLE
Dependency updates (JDK 21 compatibility)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11', '17', '20' ]
+        java: [ '11', '17', '21-ea' ]
 
     steps:
       - name: Set up JDK ${{ matrix.java }} 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -40,23 +40,23 @@ limitations under the License.
         <jstl.version>1.2</jstl.version>
         <angular.version>1.7.8</angular.version>
         <ant.version>1.10.13</ant.version>
-        <asm.version>9.4</asm.version>
+        <asm.version>9.5</asm.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <commons-validator.version>1.7</commons-validator.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-codec.version>1.15</commons-codec.version>
-        <eclipse-link.version>4.0.1</eclipse-link.version>
-        <guice.version>5.1.0</guice.version>
+        <eclipse-link.version>4.0.2</eclipse-link.version>
+        <guice.version>6.0.0</guice.version>
         <log4j2.version>2.20.0</log4j2.version>
-        <lucene.version>9.5.0</lucene.version>
+        <lucene.version>9.6.0</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
         <maven-war.version>3.3.2</maven-war.version>
         <maven-surefire.version>2.22.2</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
         <rome.version>1.19.0</rome.version> <!-- locked in place since next version removes popono -->
         <slf4j.version>1.7.36</slf4j.version>
-        <spring.version>5.3.25</spring.version>
-        <spring.security.version>5.8.2</spring.security.version>
+        <spring.version>5.3.27</spring.version>
+        <spring.security.version>5.8.3</spring.security.version>
         <struts.version>2.5.29</struts.version>
         <velocity.version>2.3</velocity.version>
         <webjars.version>1.6</webjars.version>
@@ -260,13 +260,13 @@ limitations under the License.
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>clipboard.js</artifactId>
-            <version>2.0.6</version>
+            <version>2.0.11</version>
         </dependency>
 
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>3.6.1</version>
+            <version>3.6.4</version>
         </dependency>
 
         <dependency>
@@ -591,14 +591,14 @@ limitations under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.2.4</version>
+            <version>3.12.4</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>2.9.0</version>
+            <version>2.16.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -843,7 +843,7 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>

--- a/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
@@ -5,7 +5,7 @@ You can override it with your own file via WEB-INF/tiles-def.xml
 
 <%@ include file="/WEB-INF/jsps/taglibs-struts2.jsp" %>
 
-<script src="<s:url value='/webjars/jquery/3.6.1/jquery.min.js' />"></script>
+<script src="<s:url value='/webjars/jquery/3.6.4/jquery.min.js' />"></script>
 
 <script src="<s:url value='/webjars/jquery-ui/1.13.2/jquery-ui.min.js' />"></script>
 <link href="<s:url value='/webjars/jquery-ui/1.13.2/jquery-ui.css' />" rel="stylesheet" />
@@ -16,7 +16,7 @@ You can override it with your own file via WEB-INF/tiles-def.xml
 <link href="<s:url value='/webjars/bootstrap/3.4.1/css/bootstrap-theme.min.css' />" rel="stylesheet" />
 <script src="<s:url value='/webjars/bootstrap/3.4.1/js/bootstrap.min.js' />"></script>
 
-<script src="<s:url value='/webjars/clipboard.js/2.0.6/clipboard.min.js' />"></script>
+<script src="<s:url value='/webjars/clipboard.js/2.0.11/clipboard.min.js' />"></script>
 
 <script src="<s:url value='/webjars/summernote/0.8.12/dist/summernote.min.js' />"></script>
 <link href="<s:url value='/webjars/summernote/0.8.12/dist/summernote.css' />" rel="stylesheet" />

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ limitations under the License.
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <derby.version>10.11.1.1</derby.version>
         <jaxb.version>2.3.1</jaxb.version>
-        <jetty.version>10.0.14</jetty.version>
+        <jetty.version>10.0.15</jetty.version>
         <roller.version>6.1.2-SNAPSHOT</roller.version>
     </properties>
 
@@ -113,7 +113,7 @@ limitations under the License.
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.9.2</version>
+                <version>5.9.3</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Mostly minor dependency updates which should allow roller to run on the upcoming JDK 21.

The only major update was guice, guice 6.x and 7.x are nearly identical taken from doc:

> The Guice 6.0 servlet & persist extensions only support the javax.servlet and javax.persistence namespaces respectively. If compatibility with jakarta.servlet or jakarta.persistence is required, use Guice 7.0.
> 
> Guice 7.0 removes support for javax.inject, javax.servlet and javax.persistence. Other than the namespace changes, Guice 6.0 & Guice 7.0 are identical.

updated from 5.x to 6.0 for now.