### PR TITLE
Add a Jetty event listener to start Derby when Roller is run via mvn jetty:run

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -36,7 +36,6 @@ limitations under the License.
         <servlet.version>4.0.1</servlet.version>
         <jsp-api.version>2.2</jsp-api.version>
         <java-activation.version>1.2.0</java-activation.version>
-        <java-mail.version>1.4.7</java-mail.version>
         <jstl.version>1.2</jstl.version>
         <angular.version>1.7.8</angular.version>
         <ant.version>1.10.13</ant.version>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -54,7 +54,6 @@ limitations under the License.
         <maven-surefire.version>2.22.2</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
         <rome.version>1.19.0</rome.version> <!-- locked in place since next version removes popono -->
-        <slf4j.version>1.7.36</slf4j.version>
         <spring.version>5.3.27</spring.version>
         <spring.security.version>5.8.3</spring.security.version>
         <struts.version>2.5.29</struts.version>
@@ -611,19 +610,21 @@ limitations under the License.
                     </webApp>
                     <jettyXmls>src/test/resources/jetty.xml</jettyXmls>
                     <systemProperties>
-                        <systemProperty>
-                            <name>roller.custom.config</name>
-                            <value>${project.build.directory}/test-classes/roller-jettyrun.properties</value>
-                        </systemProperty>
+                        <roller.custom.config>
+                            ${project.build.directory}/test-classes/roller-jettyrun.properties
+                        </roller.custom.config>
                     </systemProperties>
                 </configuration>
                 <dependencies>
-                    <!-- Dependencies needed when using mvn jetty:run, not mvn test -->
+                    <dependency>
+                        <groupId>org.apache.roller</groupId>
+                        <artifactId>db-utils</artifactId>
+                        <version>6.1.2</version>
+                    </dependency>
                     <dependency>
                         <groupId>commons-dbcp</groupId>
                         <artifactId>commons-dbcp</artifactId>
                         <version>1.4</version>
-                        <scope>runtime</scope>
                     </dependency>
                     <dependency>
                         <groupId>org.apache.derby</groupId>
@@ -643,49 +644,9 @@ limitations under the License.
                 </dependencies>
             </plugin>
 
-            <!-- Activates the Derby database for unit tests and mvn jetty:run
-            <plugin>
-                <groupId>com.btmatthews.maven.plugins.inmemdb</groupId>
-                <artifactId>inmemdb-maven-plugin</artifactId>
-
-                <configuration>
-                    <daemon>true</daemon>
-                    <type>derby</type>
-                    <database>rollerdb</database>
-                    <username>APP</username>
-                    <password>APP</password>
-                    <port>4224</port>
-                    <sources>
-                        <script>
-                            <sourceFile>${project.basedir}/target/dbscripts/derby/createdb.sql</sourceFile>
-                        </script>
-                    </sources>
-                    <skip>${skipTests}</skip>
-                </configuration>
-
-                <executions>
-                    <execution>
-                        <id>run</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>stop</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
-            </plugin>
-            -->
-
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.1</version>
 
                 <executions>
 
@@ -714,7 +675,7 @@ limitations under the License.
                         </goals>
                         <configuration>
                             <includeEmptyDirs>true</includeEmptyDirs>
-                            <outputDirectory>${basedir}/target/dbscripts</outputDirectory>
+                            <outputDirectory>${basedir}/target/classes/dbscripts</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>${basedir}/src/main/resources/sql</directory>
@@ -724,7 +685,7 @@ limitations under the License.
                         </configuration>
                     </execution>
 
-                    <execution>
+                    <!-- <execution>
                         <id>copy-resources</id>
                         <phase>process-resources</phase>
                         <goals>
@@ -742,7 +703,7 @@ limitations under the License.
                                 </resource>
                             </resources>
                         </configuration>
-                    </execution>
+                    </execution> -->
 
                 </executions>
 
@@ -804,7 +765,7 @@ limitations under the License.
                                 <property file="${basedir}/src/main/resources/sql/dbscripts.properties" />
                                 <for list="${databases}" param="database" delimiter=" ">
                                     <sequential>
-                                        <mkdir dir="${basedir}/target/dbscripts/@{database}" />
+                                        <mkdir dir="${basedir}/target/classes/dbscripts/@{database}" />
                                     </sequential>
                                 </for>
 
@@ -815,7 +776,7 @@ limitations under the License.
                                     controlTemplate  ="control.vm"
                                     contextProperties="${basedir}/src/main/resources/sql/dbscripts.properties"
                                     templatePath     ="${basedir}/src/main/resources/sql"
-                                    outputDirectory  ="${basedir}/target/dbscripts"
+                                    outputDirectory  ="${basedir}/target/classes/dbscripts"
                                     outputFile       ="README.txt"/>
                             </target>
                         </configuration>

--- a/app/src/main/java/org/apache/roller/weblogger/business/startup/WebloggerStartup.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/startup/WebloggerStartup.java
@@ -34,17 +34,17 @@ public final class WebloggerStartup {
     private static final Log LOG = LogFactory.getLog(WebloggerStartup.class);
     
     private static boolean prepared = false;
-    
+
     private static DatabaseProvider dbProvider = null;
     private static StartupException dbProviderException = null;
-    
+
     private static MailProvider mailProvider = null;
-    
-    
+
+
     // non-instantiable
     private WebloggerStartup() {}
-    
-    
+
+
     /**
      * Is the Roller Weblogger app properly prepared to be bootstrapped?
      */
@@ -182,7 +182,7 @@ public final class WebloggerStartup {
         }
         
         // now we need to deal with database install/upgrade logic
-        if("manual".equals(WebloggerConfig.getProperty("installation.type"))) {
+        if ("manual".equals(WebloggerConfig.getProperty("installation.type"))) {
             
             // if we are doing manual install then all that is needed is the
             // app handled database upgrade work, not the db scripts
@@ -193,7 +193,7 @@ public final class WebloggerStartup {
             
             prepared = true;
             
-        } else {
+        } else if ("auto".equals(WebloggerConfig.getProperty("installation.type"))) {
             
             // we are in auto install mode, so see if there is any work to do
             DatabaseInstaller dbInstaller = getDatabaseInstaller();

--- a/app/src/main/java/org/apache/roller/weblogger/ui/core/RollerContext.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/core/RollerContext.java
@@ -157,18 +157,28 @@ public class RollerContext extends ContextLoaderListener
             return;
         }
 
+        final boolean ittest = "ittest".equals(WebloggerConfig.getProperty("installation.type"));
 
         // if preparation failed or is incomplete then we are done,
         // otherwise try to bootstrap the business tier
-        if (!WebloggerStartup.isPrepared()) {
+        if (!WebloggerStartup.isPrepared() && !ittest) {
+
             StringBuilder buf = new StringBuilder();
             buf.append("\n--------------------------------------------------------------");
             buf.append("\nRoller Weblogger startup INCOMPLETE, user interaction required");
             buf.append("\n--------------------------------------------------------------");
             log.info(buf.toString());
-        } else {
-            Weblogger weblogger = null;
 
+        } else {
+            if (ittest) {
+                try {
+                    WebloggerStartup.createDatabase();
+                } catch (StartupException e) {
+                    throw new RuntimeException("Failed to create database to IT testing", e);
+                }
+            }
+
+            Weblogger weblogger = null;
             try {
                 // trigger bootstrapping process
                 WebloggerFactory.bootstrap();
@@ -198,7 +208,6 @@ public class RollerContext extends ContextLoaderListener
         } catch (WebloggerException ex) {
             log.fatal("Error initializing Roller Weblogger web tier", ex);
         }
-
     }
 
 
@@ -211,7 +220,6 @@ public class RollerContext extends ContextLoaderListener
         // do we need a more generic mechanism for presentation layer shutdown?
         CacheManager.shutdown();
     }
-
 
     /**
      * Initialize the Velocity rendering engine.

--- a/app/src/test/java/org/apache/roller/weblogger/TestUtils.java
+++ b/app/src/test/java/org/apache/roller/weblogger/TestUtils.java
@@ -74,7 +74,7 @@ public final class TestUtils {
         if (!WebloggerFactory.isBootstrapped()) {
             synchronized (TestUtils.class) {
                 if (derbyManager == null) {
-                    derbyManager = new DerbyManager("./target/testdb", "./target/dbscripts", 4224);
+                    derbyManager = new DerbyManager("./target/testdb", "./target/classes/dbscripts", 4224);
                     derbyManager.startDerby();
                 }
             }

--- a/app/src/test/resources/jetty.xml
+++ b/app/src/test/resources/jetty.xml
@@ -20,7 +20,7 @@
 
 <!-- Dummy values used only when testing with Jetty via mvn jetty:run -->
 
-<Configure>
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
 
     <New id="ds" class="org.eclipse.jetty.plus.jndi.Resource">
         <Arg> <Ref id="wac_ds"/> </Arg>
@@ -49,5 +49,11 @@
             </New>
         </Arg>
     </New>
+
+    <Call name="addEventListener">
+        <Arg>
+            <New class="org.apache.roller.testutils.DerbyLifeCycle"/>
+        </Arg>
+    </Call>
 
 </Configure>

--- a/app/src/test/resources/roller-jettyrun.properties
+++ b/app/src/test/resources/roller-jettyrun.properties
@@ -5,7 +5,7 @@ planet.aggregator.enabled=true
 
 database.configurationType=jdbc
 database.jdbc.driverClass=org.apache.derby.jdbc.ClientDriver
-# In-memory Derby database activated via "startdb" execution in app/pom.xml
+# In-memory Derby database activated via db-utils module
 database.jdbc.connectionURL=jdbc:derby://localhost:4224/memory:rollerdb;create=true
 database.jdbc.username=app
 database.jdbc.password=app

--- a/db-utils/pom.xml
+++ b/db-utils/pom.xml
@@ -1,0 +1,62 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.roller</groupId>
+        <artifactId>roller-project</artifactId>
+        <version>6.1.2</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <name>Apache Roller DB Utilities</name>
+    <artifactId>db-utils</artifactId>
+    <version>6.1.2</version>
+
+    <build>
+        <plugins>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- slf4j implementing the apache commons-logging interfaces -->
+        <!-- note: commons-logging needs to be excluded in all dependencies transitive depending on it.
+        See 2006 RFE https://issues.apache.org/jira/browse/MNG-1977 for maven's missing feature of global exclusions -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derbynet</artifactId>
+            <version>${derby.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>${derby.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${jetty.plugin.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/db-utils/src/main/java/org/apache/roller/testutils/DerbyLifeCycle.java
+++ b/db-utils/src/main/java/org/apache/roller/testutils/DerbyLifeCycle.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  The ASF licenses this file to You
+ * under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.  For additional information regarding
+ * copyright in this work, please see the NOTICE file in the top level
+ * directory of this distribution.
+ */
+
+package org.apache.roller.testutils;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.derby.drda.NetworkServerControl;
+import org.eclipse.jetty.util.component.LifeCycle;
+import java.io.PrintWriter;
+
+/**
+ * Enables start and stop Derby from the Maven Jetty plugin.
+ */
+public class DerbyLifeCycle implements LifeCycle.Listener {
+    private static final Log log = LogFactory.getFactory().getInstance(DerbyLifeCycle.class);
+
+    private void setupDerby() {
+        System.setProperty("derby.system.home", "./target/derby");
+        System.setProperty("derby.drda.portNumber", "4224");
+        System.setProperty("derby.drda.host", "localhost");
+    }
+
+    @Override
+    public void lifeCycleStarting(LifeCycle event) {
+        log.info("**************");
+        log.info("Starting Derby");
+        log.info("**************");
+        try {
+            setupDerby();
+            NetworkServerControl server = new NetworkServerControl();
+            server.start(new PrintWriter(System.out));
+            try {Thread.sleep(2000);} catch (Exception ignored) {}
+        } catch (Exception e) {
+            log.error("Error starting Derby", e);
+        }
+    }
+
+    @Override
+    public void lifeCycleStopped(LifeCycle event) {
+        log.info("**************");
+        log.info("Stopping Derby");
+        log.info("**************");
+        try {
+            setupDerby();
+            NetworkServerControl server = new NetworkServerControl();
+            server.shutdown();
+            try {Thread.sleep(2000);} catch (Exception ignored) {}
+        } catch (Exception e) {
+            log.error("Error stopping Derby", e);
+        }
+    }
+}

--- a/it-selenium/pom.xml
+++ b/it-selenium/pom.xml
@@ -152,42 +152,6 @@
                 </dependencies>                    
             </plugin>
 
-            <!-- Activates the Derby database during the integration test phase -->
-            <plugin>
-                <groupId>com.btmatthews.maven.plugins.inmemdb</groupId>
-                <artifactId>inmemdb-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>run</id>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <daemon>true</daemon>
-                            <type>derby</type>
-                            <database>rollerdb</database>
-                            <username>APP</username>
-                            <password>APP</password>
-                            <port>4224</port>
-                            <sources>
-                                <script>
-                                    <sourceFile>${project.basedir}/target/roller-selenium-tests-${project.version}/WEB-INF/classes/dbscripts/derby/createdb.sql</sourceFile>
-                                </script>
-                            </sources>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>stop</id>
-                        <!-- Moving later to verify phase from post-integration-test.  Reason: Jetty shutdown wants
-                             to close database or will raise error messages. -->
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>stop</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <!-- Activates the Roller application during the integration test phase -->
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>

--- a/it-selenium/pom.xml
+++ b/it-selenium/pom.xml
@@ -165,10 +165,9 @@
                     <webAppSourceDirectory>target/roller-selenium-tests-${project.version}</webAppSourceDirectory>
                     <jettyXmls>${project.parent.basedir}/app/src/test/resources/jetty.xml</jettyXmls>
                     <systemProperties>
-                        <systemProperty>
-                            <name>roller.custom.config</name>
-                            <value>src/test/resources/roller-jettyrun.properties</value>
-                        </systemProperty>
+                        <roller.custom.config>
+                            src/test/resources/roller-jettyrun.properties
+                        </roller.custom.config>
                     </systemProperties>
                 </configuration>
                 <executions>
@@ -192,51 +191,31 @@
                     </execution>
                 </executions>
                 <dependencies>
-                            
+                    <dependency>
+                        <groupId>org.apache.roller</groupId>
+                        <artifactId>db-utils</artifactId>
+                        <version>6.1.2</version>
+                    </dependency>
                     <dependency>
                         <groupId>commons-dbcp</groupId>
                         <artifactId>commons-dbcp</artifactId>
                         <version>1.4</version>
                     </dependency>
-
                     <dependency>
                         <groupId>org.apache.derby</groupId>
                         <artifactId>derby</artifactId>
                         <version>${derby.version}</version>
                     </dependency>
-
                     <dependency>
                         <groupId>org.apache.derby</groupId>
                         <artifactId>derbyclient</artifactId>
                         <version>${derby.version}</version>
                     </dependency>
-
-                    <dependency>
-                        <groupId>commons-dbcp</groupId>
-                        <artifactId>commons-dbcp</artifactId>
-                        <version>1.4</version>
-                        <scope>runtime</scope>
-                    </dependency>
-
                     <dependency>
                         <groupId>javax.mail</groupId>
                         <artifactId>mail</artifactId>
-                        <version>1.4.7</version>
+                        <version>${java-mail.version}</version>
                     </dependency>
-
-                    <dependency>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                        <version>${jaxb.version}</version>
-                        <exclusions>
-                            <exclusion>
-                                <!--api is already in the javax.activation artifact-->
-                                <groupId>javax.activation</groupId>
-                                <artifactId>javax.activation-api</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
-
                 </dependencies>
             </plugin>
         </plugins>

--- a/it-selenium/src/test/resources/roller-jettyrun.properties
+++ b/it-selenium/src/test/resources/roller-jettyrun.properties
@@ -1,12 +1,12 @@
 # copied from roller-jettyrun.properties in "app" submodule,
 # Differences: no filtering done here and themes.dir location has changed.
 # Hopefully this file can be obsoleted and the one in app referenced directly
-installation.type=auto
+installation.type=ittest
 planet.aggregator.enabled=true
 
 database.configurationType=jdbc
 database.jdbc.driverClass=org.apache.derby.jdbc.ClientDriver
-# In-memory Derby database activated via "startdb" execution in app/pom.xml
+# In-memory Derby database activated via db-utils module
 database.jdbc.connectionURL=jdbc:derby://localhost:4224/memory:rollerdb;create=true
 database.jdbc.username=app
 database.jdbc.password=app

--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,14 @@ limitations under the License.
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <derby.version>10.11.1.1</derby.version>
         <jaxb.version>2.3.1</jaxb.version>
-        <jetty.version>10.0.15</jetty.version>
+        <jetty.plugin.version>10.0.16</jetty.plugin.version> <!-- Jetty 11 requires Jakarta package names -->
         <roller.version>6.1.2</roller.version>
+        <slf4j.version>1.7.36</slf4j.version>
     </properties>
 
     <modules>
         <module>app</module>
+        <module>db-utils</module>
         <!-- <module>it-selenium</module> -->
     </modules>
 
@@ -85,7 +87,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-maven-plugin</artifactId>
-                    <version>${jetty.version}</version>
+                    <version>${jetty.plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -93,15 +95,6 @@ limitations under the License.
                     <version>2.15.0</version>
                     <configuration>
                         <rulesUri>file:version-rules.xml</rulesUri>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>com.btmatthews.maven.plugins.inmemdb</groupId>
-                    <artifactId>inmemdb-maven-plugin</artifactId>
-                    <version>1.4.3</version>
-                    <configuration>
-                        <monitorKey>inmemdb</monitorKey>
-                        <monitorPort>11527</monitorPort>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,12 @@ limitations under the License.
     </scm>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <derby.version>10.11.1.1</derby.version>
+        <java-mail.version>1.4.7</java-mail.version>
         <jaxb.version>2.3.1</jaxb.version>
         <jetty.plugin.version>10.0.16</jetty.plugin.version> <!-- Jetty 11 requires Jakarta package names -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <roller.version>6.1.2</roller.version>
         <slf4j.version>1.7.36</slf4j.version>
     </properties>


### PR DESCRIPTION
This PR fixes a regression caused by switching Roller from using the Maven `btmatthews` `inmemdb` plugin and instead starting Derby by calling the embedded Derby server API directly (which works when tests are run either in IntelliJ or in Maven).  The problem was that I forgot to add the same logic to the Maven Jetty plugin so that Derby is started when Roller is run via `mvn jetty:run`.

The Jira ticket: https://issues.apache.org/jira/browse/ROL-2182
