### PR TITLE
Dependency updates and some compiler warning cleanup in tests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,13 +30,13 @@ jobs:
 
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'
   
       - name: Checkout Project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           submodules: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Set up JDK ${{ matrix.java }} 
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }} 
           distribution: 'zulu'
@@ -59,7 +59,7 @@ jobs:
       - name: Run Integration Tests
         run: |
           cd it-selenium
-          mvn -V -ntp -Dwebdriver.gecko.driver=$GECKOWEBDRIVER/geckodriver install
+          mvn -V -ntp install
 
       - name: Publish JUnit Report
         uses: test-summary/action@v2
@@ -76,7 +76,7 @@ jobs:
       # only on integration and only once in this matrix
       - name: Upload Dev Build on Integration
         if: ${{ (matrix.java == '11') && (github.event_name == 'push') }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dev-build
           path: ./app/target/roller.war

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -38,23 +38,26 @@ limitations under the License.
         <java-activation.version>1.2.0</java-activation.version>
         <jstl.version>1.2</jstl.version>
         <angular.version>1.7.8</angular.version>
-        <ant.version>1.10.13</ant.version>
-        <asm.version>9.5</asm.version>
+        <ant.version>1.10.14</ant.version>
+        <asm.version>9.6</asm.version>
         <bouncycastle.version>1.70</bouncycastle.version>
-        <commons-validator.version>1.7</commons-validator.version>
+        <commons-validator.version>1.8.0</commons-validator.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
-        <commons-codec.version>1.15</commons-codec.version>
+        <commons-codec.version>1.16.0</commons-codec.version>
+        <commons-text.version>1.11.0</commons-text.version>
+        <commons-lang3.version>3.14.0</commons-lang3.version>
         <eclipse-link.version>4.0.2</eclipse-link.version>
-        <guice.version>6.0.0</guice.version>
-        <log4j2.version>2.20.0</log4j2.version>
-        <lucene.version>9.6.0</lucene.version>
+        <guice.version>7.0.0</guice.version>
+        <log4j2.version>2.22.1</log4j2.version>
+        <lucene.version>9.9.1</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
-        <maven-war.version>3.3.2</maven-war.version>
-        <maven-surefire.version>2.22.2</maven-surefire.version>
+        <maven-war.version>3.4.0</maven-war.version>
+        <maven-surefire.version>3.2.5</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
         <rome.version>1.19.0</rome.version> <!-- locked in place since next version removes popono -->
-        <spring.version>5.3.27</spring.version>
-        <spring.security.version>5.8.3</spring.security.version>
+        <slf4j.version>2.0.11</slf4j.version>
+        <spring.version>5.3.31</spring.version>
+        <spring.security.version>5.8.8</spring.security.version>
         <struts.version>2.5.29</struts.version>
         <velocity.version>2.3</velocity.version>
         <webjars.version>1.6</webjars.version>
@@ -264,7 +267,7 @@ limitations under the License.
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>3.6.4</version>
+            <version>3.7.1</version>
         </dependency>
 
         <dependency>
@@ -363,8 +366,14 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.10.0</version>
+            <version>${commons-text.version}</version>
          </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.xmlrpc</groupId>
@@ -497,7 +506,7 @@ limitations under the License.
         <dependency>
             <groupId>com.jgeppert.struts2.bootstrap</groupId>
             <artifactId>struts2-bootstrap-plugin</artifactId>
-            <version>4.0.1</version>
+            <version>4.0.0</version>
         </dependency>
 
         <dependency>
@@ -572,14 +581,14 @@ limitations under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.4</version>
+            <version>5.9.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>2.16.0</version>
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -728,7 +737,7 @@ limitations under the License.
 
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>ant-contrib</groupId>
@@ -786,7 +795,7 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>

--- a/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
@@ -5,7 +5,7 @@ You can override it with your own file via WEB-INF/tiles-def.xml
 
 <%@ include file="/WEB-INF/jsps/taglibs-struts2.jsp" %>
 
-<script src="<s:url value='/webjars/jquery/3.6.4/jquery.min.js' />"></script>
+<script src="<s:url value='/webjars/jquery/3.7.1/jquery.min.js' />"></script>
 
 <script src="<s:url value='/webjars/jquery-ui/1.13.2/jquery-ui.min.js' />"></script>
 <link href="<s:url value='/webjars/jquery-ui/1.13.2/jquery-ui.css' />" rel="stylesheet" />

--- a/app/src/test/java/org/apache/roller/planet/business/GroupFunctionalTests.java
+++ b/app/src/test/java/org/apache/roller/planet/business/GroupFunctionalTests.java
@@ -74,7 +74,7 @@ public class GroupFunctionalTests  {
         
         // lookup all groups in planet
         Planet planet = mgr.getWebloggerById(testPlanet.getId());
-        Set groups = planet.getGroups();
+        Set<PlanetGroup> groups = planet.getGroups();
         assertNotNull(groups);
         assertEquals(2, groups.size());
     }

--- a/app/src/test/java/org/apache/roller/planet/business/PlanetFunctionalTests.java
+++ b/app/src/test/java/org/apache/roller/planet/business/PlanetFunctionalTests.java
@@ -74,7 +74,7 @@ public class PlanetFunctionalTests  {
         assertEquals("planetFuncTest", planet.getHandle());
         
         // all planets (should be 2, the default and the one we created)
-        List planets = mgr.getWebloggers();
+        List<Planet> planets = mgr.getWebloggers();
         assertNotNull(planets);
         assertEquals(2, planets.size());
     }

--- a/app/src/test/java/org/apache/roller/weblogger/business/BookmarkTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/BookmarkTest.java
@@ -205,7 +205,7 @@ public class BookmarkTest  {
         
         // test lookup of all bookmarks in single folder
         WeblogBookmarkFolder testFolder = bmgr.getFolder(f1.getId());
-        List allBookmarks = bmgr.getBookmarks(testFolder);
+        List<WeblogBookmark> allBookmarks = bmgr.getBookmarks(testFolder);
         assertNotNull(allBookmarks);
         assertEquals(2, allBookmarks.size());
         

--- a/app/src/test/java/org/apache/roller/weblogger/business/CommentTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/CommentTest.java
@@ -135,7 +135,7 @@ public class CommentTest  {
     public void testCommentLookups() throws Exception {
         
         WeblogEntryManager mgr = WebloggerFactory.getWeblogger().getWeblogEntryManager();
-        List comments;
+        List<WeblogEntryComment> comments;
         
         // we need some comments to play with
         testEntry = TestUtils.getManagedWeblogEntry(testEntry);

--- a/app/src/test/java/org/apache/roller/weblogger/business/FolderFunctionalityTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/FolderFunctionalityTest.java
@@ -205,7 +205,7 @@ public class FolderFunctionalityTest  {
         
         // get all folders, including root
         testWeblog = TestUtils.getManagedWebsite(testWeblog);
-        List allFolders = bmgr.getAllFolders(testWeblog);
+        List<WeblogBookmarkFolder> allFolders = bmgr.getAllFolders(testWeblog);
         assertNotNull(allFolders);
         assertEquals(5, allFolders.size());
         

--- a/app/src/test/java/org/apache/roller/weblogger/business/HitCountTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/HitCountTest.java
@@ -286,15 +286,15 @@ public class HitCountTest  {
         assertEquals(30, testCount.getDailyHits());
         
         // get hot weblogs
-        List hotBlogs = mgr.getHotWeblogs(1, 0, 5);
+        List<WeblogHitCount> hotBlogs = mgr.getHotWeblogs(1, 0, 5);
         assertNotNull(hotBlogs);
         assertEquals(3, hotBlogs.size());
         
         // also check ordering and values
         WeblogHitCount hitCount;
-        Iterator it = hotBlogs.iterator();
+        Iterator<WeblogHitCount> it = hotBlogs.iterator();
         for (int i=3; it.hasNext(); i--) {
-            hitCount = (WeblogHitCount) it.next();
+            hitCount = it.next();
             assertEquals(i*10, hitCount.getDailyHits());
         }
         

--- a/app/src/test/java/org/apache/roller/weblogger/business/MediaFileTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/MediaFileTest.java
@@ -509,14 +509,13 @@ public class MediaFileTest  {
             assertFalse(searchResults.isEmpty());
             assertEquals(id2, (searchResults.get(0)).getId());
             assertNotNull((searchResults.get(0)).getDirectory());
-            assertEquals("default", (searchResults.get(0)).getDirectory()
-                    .getName());
+            assertEquals("default", searchResults.get(0).getDirectory().getName());
 
             MediaFileFilter filter3 = new MediaFileFilter();
             filter3.setName("test_work.jpg");
             searchResults = mfMgr.searchMediaFiles(testWeblog, filter3);
             assertFalse(searchResults.isEmpty());
-            assertEquals(id1, ((MediaFile) searchResults.get(0)).getId());
+            assertEquals(id1, searchResults.get(0).getId());
 
             // search by tag
 
@@ -540,8 +539,7 @@ public class MediaFileTest  {
             searchResults = mfMgr.searchMediaFiles(testWeblog, filter4);
             assertFalse(searchResults.isEmpty());
             assertEquals(1, searchResults.size());
-            assertEquals("test_work.jpg",
-                    ((MediaFile) searchResults.get(0)).getName());
+            assertEquals("test_work.jpg", searchResults.get(0).getName());
 
             // search by size
 
@@ -551,8 +549,7 @@ public class MediaFileTest  {
             searchResults = mfMgr.searchMediaFiles(testWeblog, filter6);
             assertFalse(searchResults.isEmpty());
             assertEquals(1, searchResults.size());
-            assertEquals("test_work.jpg",
-                    ((MediaFile) searchResults.get(0)).getName());
+            assertEquals("test_work.jpg", searchResults.get(0).getName());
 
             MediaFileFilter filter7 = new MediaFileFilter();
             filter7.setSize(3000);
@@ -560,8 +557,7 @@ public class MediaFileTest  {
             searchResults = mfMgr.searchMediaFiles(testWeblog, filter7);
             assertFalse(searchResults.isEmpty());
             assertEquals(1, searchResults.size());
-            assertEquals("test_home.jpg",
-                    ((MediaFile) searchResults.get(0)).getName());
+            assertEquals("test_home.jpg", searchResults.get(0).getName());
 
             MediaFileFilter filter8 = new MediaFileFilter();
             filter8.setSize(3000);
@@ -569,8 +565,7 @@ public class MediaFileTest  {
             searchResults = mfMgr.searchMediaFiles(testWeblog, filter8);
             assertFalse(searchResults.isEmpty());
             assertEquals(1, searchResults.size());
-            assertEquals("test_pers.jpg",
-                    ((MediaFile) searchResults.get(0)).getName());
+            assertEquals("test_pers.jpg", searchResults.get(0).getName());
 
             MediaFileFilter filter9 = new MediaFileFilter();
             filter9.setSize(3000);

--- a/app/src/test/java/org/apache/roller/weblogger/business/PermissionTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/PermissionTest.java
@@ -124,7 +124,7 @@ public class PermissionTest  {
         assertNull(perm);
         
         // create permissions
-        List<String> actions = new ArrayList<String>();
+        List<String> actions = new ArrayList<>();
         actions.add(WeblogPermission.ADMIN);
         actions.add(WeblogPermission.POST);
         mgr.grantWeblogPermission(testWeblog, testUser, actions);
@@ -189,7 +189,7 @@ public class PermissionTest  {
         perms = mgr.getWeblogPermissions(TestUtils.getManagedWebsite(testWeblog));
         assertEquals(1, perms.size());
 
-        List<String> actions = new ArrayList<String>();
+        List<String> actions = new ArrayList<>();
         actions.add(WeblogPermission.POST);
         mgr.grantWeblogPermissionPending(testWeblog, user, actions);
         TestUtils.endSession(true);
@@ -244,11 +244,9 @@ public class PermissionTest  {
 
         WeblogManager wmgr = WebloggerFactory.getWeblogger().getWeblogManager();
         UserManager umgr = WebloggerFactory.getWeblogger().getUserManager();
-        WeblogPermission perm = null;
-        List perms = null;
 
         // invite user to weblog
-        List<String> actions = new ArrayList<String>();
+        List<String> actions = new ArrayList<>();
         actions.add(WeblogPermission.EDIT_DRAFT);
         umgr.grantWeblogPermissionPending(testWeblog, user, actions);
         TestUtils.endSession(true);
@@ -269,12 +267,12 @@ public class PermissionTest  {
 
         // assert that user is member of weblog
         assertNotNull(umgr.getWeblogPermission(testWeblog, user));
-        List weblogs = wmgr.getUserWeblogs(TestUtils.getManagedUser(user), true);
+        List<Weblog> weblogs = wmgr.getUserWeblogs(TestUtils.getManagedUser(user), true);
         assertEquals(1, weblogs.size());
-        assertEquals(testWeblog.getId(), ((Weblog)weblogs.get(0)).getId());
+        assertEquals(testWeblog.getId(), weblogs.get(0).getId());
 
         // assert that website has user
-        List users = wmgr.getWeblogUsers(testWeblog, true);
+        List<User> users = wmgr.getWeblogUsers(testWeblog, true);
         assertEquals(2, users.size());
 
         // test user can be retired from website

--- a/app/src/test/java/org/apache/roller/weblogger/business/PingsTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/PingsTest.java
@@ -159,7 +159,7 @@ public class PingsTest  {
         assertEquals(testCommonPing.getName(), ping.getName());
         
         // lookup all common pings
-        List commonPings = mgr.getCommonPingTargets();
+        List<PingTarget> commonPings = mgr.getCommonPingTargets();
         assertNotNull(commonPings);
         // correct answer is: 4 pings in config + 1 new one = 5
         assertEquals(5, commonPings.size());
@@ -331,7 +331,7 @@ public class PingsTest  {
         
         // lookup by ping target
         pingTarget = ptmgr.getPingTarget(pingTarget.getId());
-        List autoPings = mgr.getAutoPingsByTarget(pingTarget);
+        List<AutoPing> autoPings = mgr.getAutoPingsByTarget(pingTarget);
         assertNotNull(autoPings);
         assertEquals(1, autoPings.size());
         

--- a/app/src/test/java/org/apache/roller/weblogger/business/PlanetManagerLocalTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/PlanetManagerLocalTest.java
@@ -21,6 +21,7 @@ import org.apache.roller.planet.business.PlanetManager;
 import org.apache.roller.planet.pojos.Planet;
 import org.apache.roller.planet.pojos.PlanetGroup;
 import org.apache.roller.planet.pojos.Subscription;
+import org.apache.roller.planet.pojos.SubscriptionEntry;
 import org.apache.roller.weblogger.TestUtils;
 import org.apache.roller.weblogger.planet.tasks.RefreshRollerPlanetTask;
 import org.apache.roller.weblogger.planet.tasks.SyncWebsitesTask;
@@ -155,7 +156,7 @@ public class PlanetManagerLocalTest  {
             
             planetObject = planet.getWeblogger("default");
             group = planet.getGroup(planetObject, "all");
-            List agg = planet.getEntries(group, 0, -1);
+            List<SubscriptionEntry> agg = planet.getEntries(group, 0, -1);
             assertEquals(3, agg.size());
         }
         catch (Exception e) {

--- a/app/src/test/java/org/apache/roller/weblogger/business/UserTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/UserTest.java
@@ -136,17 +136,17 @@ public class UserTest  {
         
         // lookup by UserName (part)
         user = null;
-        List users1 = mgr.getUsersStartingWith(testUser.getUserName().substring(0, 3), Boolean.TRUE, 0, 1);
+        List<User> users1 = mgr.getUsersStartingWith(testUser.getUserName().substring(0, 3), Boolean.TRUE, 0, 1);
         assertEquals(1, users1.size());
-        user = (User) users1.get(0);
+        user = users1.get(0);
         assertNotNull(user);
         assertEquals(testUser.getUserName(), user.getUserName());
         
         // lookup by Email (part)
         user = null;
-        List users2 = mgr.getUsersStartingWith(testUser.getEmailAddress().substring(0, 3), Boolean.TRUE, 0, 1);
+        List<User> users2 = mgr.getUsersStartingWith(testUser.getEmailAddress().substring(0, 3), Boolean.TRUE, 0, 1);
         assertEquals(1, users2.size());
-        user = (User) users2.get(0);
+        user = users2.get(0);
         assertNotNull(user);
         assertEquals(testUser.getUserName(), user.getUserName());
         

--- a/app/src/test/java/org/apache/roller/weblogger/business/WeblogCategoryFunctionalityTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/WeblogCategoryFunctionalityTest.java
@@ -168,7 +168,7 @@ public class WeblogCategoryFunctionalityTest  {
         WeblogEntryManager mgr = WebloggerFactory.getWeblogger().getWeblogEntryManager();
         
         testWeblog = TestUtils.getManagedWebsite(testWeblog);
-        List cats = mgr.getWeblogCategories(testWeblog);
+        List<WeblogCategory> cats = mgr.getWeblogCategories(testWeblog);
         assertNotNull(cats);
         assertEquals(5, cats.size());
         

--- a/app/src/test/java/org/apache/roller/weblogger/business/WeblogEntryTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/WeblogEntryTest.java
@@ -145,8 +145,8 @@ public class WeblogEntryTest  {
         
         WeblogEntryManager mgr = WebloggerFactory.getWeblogger().getWeblogEntryManager();
         WeblogEntry entry;
-        List entries;
-        Map entryMap;
+        List<WeblogEntry> entries;
+        Map<Date, ?> entryMap;
 
         // setup some test entries to use
         testWeblog = TestUtils.getManagedWebsite(testWeblog);
@@ -557,9 +557,9 @@ public class WeblogEntryTest  {
             wesc.setWeblog(testWeblog);
             // tags are always saved lowercase (testTag -> testtag)
             wesc.setTags(Arrays.asList("testtag"));
-            List results = mgr.getWeblogEntries(wesc);
+            List<WeblogEntry> results = mgr.getWeblogEntries(wesc);
             assertEquals(1, results.size());
-            WeblogEntry testEntry = (WeblogEntry) results.iterator().next();
+            WeblogEntry testEntry = results.iterator().next();
             assertEquals(entry, testEntry);
         
             // teardown our test entry
@@ -594,9 +594,9 @@ public class WeblogEntryTest  {
         wesc.setWeblog(testWeblog);
         // tags are always saved lowercase (testTag -> testtag)
         wesc.setTags(Arrays.asList("testtag"));
-        List results = mgr.getWeblogEntries(wesc);
+        List<WeblogEntry> results = mgr.getWeblogEntries(wesc);
         assertEquals(1, results.size());
-        WeblogEntry testEntry = (WeblogEntry) results.iterator().next();
+        WeblogEntry testEntry = results.iterator().next();
         assertEquals(entry, testEntry);
 
         // teardown our test entry

--- a/app/src/test/java/org/apache/roller/weblogger/business/WeblogPageTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/WeblogPageTest.java
@@ -161,7 +161,7 @@ public class WeblogPageTest  {
         assertNotNull(page);
 
         // lookup all pages for weblog
-        List pages = mgr.getTemplates(testWeblog);
+        List<WeblogTemplate> pages = mgr.getTemplates(testWeblog);
         assertNotNull(pages);
         assertEquals(1, pages.size());
         

--- a/app/src/test/java/org/apache/roller/weblogger/business/WeblogStatsTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/WeblogStatsTest.java
@@ -76,18 +76,18 @@ public class WeblogStatsTest  {
     @Test
     public void testGetMostCommentedWeblogs() throws Exception {        
         WeblogManager mgr = WebloggerFactory.getWeblogger().getWeblogManager();     
-        List list = mgr.getMostCommentedWeblogs(null, null, 0, -1);  
+        List<StatCount> list = mgr.getMostCommentedWeblogs(null, null, 0, -1);  
         
         assertNotNull(list);
         assertEquals(2, list.size());
         
-        StatCount s1 = (StatCount)list.get(0);
+        StatCount s1 = list.get(0);
         assertEquals(website1.getId(), s1.getSubjectId());
         assertEquals(3L, s1.getCount());   
         assertEquals(website1.getHandle(), s1.getSubjectNameShort());
         assertEquals(website1.getHandle(), s1.getWeblogHandle());
         
-        StatCount s2 = (StatCount)list.get(1);
+        StatCount s2 = list.get(1);
         assertEquals(website2.getId(), s2.getSubjectId());
         assertEquals(1L, s2.getCount());   
     }
@@ -96,24 +96,24 @@ public class WeblogStatsTest  {
     public void testGetMostCommentedWeblogEntries() throws Exception {
         
         WeblogEntryManager mgr = WebloggerFactory.getWeblogger().getWeblogEntryManager();      
-        List list = mgr.getMostCommentedWeblogEntries(null, null, null, 0, -1);
+        List<StatCount> list = mgr.getMostCommentedWeblogEntries(null, null, null, 0, -1);
         
         assertNotNull(list);
         assertEquals(3, list.size());
         
-        StatCount s1 = (StatCount)list.get(0);
+        StatCount s1 = list.get(0);
         assertEquals(2L, s1.getCount()); 
         assertEquals(entry11.getAnchor(), s1.getSubjectNameShort());
         assertEquals(entry11.getWebsite().getHandle(), s1.getWeblogHandle());
                
-        StatCount s2 = (StatCount)list.get(1);
+        StatCount s2 = list.get(1);
         assertEquals(1L, s2.getCount());   
     }
 
     @Test
     public void testGetUserNameLetterMap() throws Exception {        
         UserManager mgr = WebloggerFactory.getWeblogger().getUserManager();      
-        Map map = mgr.getUserNameLetterMap();    
+        Map<String, Long> map = mgr.getUserNameLetterMap();    
         assertNotNull(map.get("A"));
         assertNotNull(map.get("B"));
         assertNotNull(map.get("C"));
@@ -122,7 +122,7 @@ public class WeblogStatsTest  {
     @Test
     public void testGetWeblogLetterMap() throws Exception {        
         WeblogManager mgr = WebloggerFactory.getWeblogger().getWeblogManager();
-        Map map = mgr.getWeblogHandleLetterMap();    
+        Map<String, Long> map = mgr.getWeblogHandleLetterMap();    
         assertNotNull(map.get("A"));
         assertNotNull(map.get("B"));
         assertNotNull(map.get("C"));

--- a/app/src/test/java/org/apache/roller/weblogger/business/WeblogTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/WeblogTest.java
@@ -199,25 +199,25 @@ public class WeblogTest  {
             
             // get all weblogs for user
             weblog = null;
-            List weblogs1 = mgr.getUserWeblogs(TestUtils.getManagedUser(testUser), true);
+            List<Weblog> weblogs1 = mgr.getUserWeblogs(TestUtils.getManagedUser(testUser), true);
             assertEquals(2, weblogs1.size());
-            weblog = (Weblog) weblogs1.get(0);
+            weblog = weblogs1.get(0);
             assertNotNull(weblog);           
             
             // make sure disabled weblogs are not returned
             weblog.setVisible(Boolean.FALSE);
             mgr.saveWeblog(weblog);
             TestUtils.endSession(true);
-            List weblogs2 = mgr.getUserWeblogs(TestUtils.getManagedUser(testUser), true);
+            List<Weblog> weblogs2 = mgr.getUserWeblogs(TestUtils.getManagedUser(testUser), true);
             assertEquals(1, weblogs2.size());
-            weblog = (Weblog) weblogs2.get(0);
+            weblog = weblogs2.get(0);
             assertNotNull(weblog);
             
             // make sure inactive weblogs are not returned
             weblog.setActive(Boolean.FALSE);
             mgr.saveWeblog(weblog);
             TestUtils.endSession(true);
-            List weblogs3 = mgr.getUserWeblogs(TestUtils.getManagedUser(testUser), true);
+            List<Weblog> weblogs3 = mgr.getUserWeblogs(TestUtils.getManagedUser(testUser), true);
             assertEquals(0, weblogs3.size());
             
         } finally {

--- a/app/src/test/java/org/apache/roller/weblogger/ui/ApplicationResourcesTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/ApplicationResourcesTest.java
@@ -95,7 +95,7 @@ public class ApplicationResourcesTest {
 					+ bundle
 					+ ".properties"));
 
-		Set keys = baseProps.keySet();
+		Set<Object> keys = baseProps.keySet();
 		boolean missingMessage = false;
 
 		// check Chinese

--- a/db-utils/pom.xml
+++ b/db-utils/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
+            <version>3.14.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/it-selenium/nbactions.xml
+++ b/it-selenium/nbactions.xml
@@ -8,10 +8,6 @@
             <goal>clean</goal>
             <goal>install</goal>
         </goals>
-        <properties>
-            <!-- change path or copy driver to apache-roller/it-selenium/ -->
-            <webdriver.gecko.driver>geckodriver</webdriver.gecko.driver>
-        </properties>
     </action>
 
     <action>
@@ -23,8 +19,6 @@
         </goals>
         <properties>
             <jpda.listen>maven</jpda.listen>
-            <!-- change path or copy driver to apache-roller/it-selenium/ -->
-            <webdriver.gecko.driver>geckodriver</webdriver.gecko.driver>
         </properties>
     </action>
 

--- a/it-selenium/pom.xml
+++ b/it-selenium/pom.xml
@@ -48,20 +48,14 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>3.141.59</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>4.17.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-firefox-driver</artifactId>
-            <version>3.141.59</version>
+            <version>4.17.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>
@@ -128,13 +122,13 @@
                  can be removed once maven itself bumped the version -->
             <plugin>
                <artifactId>maven-war-plugin</artifactId>
-               <version>3.3.1</version>
+               <version>3.4.0</version>
             </plugin>
              
             <!-- Activates integration tests (by default, classes under tests that end with "IT") -->
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.2.5</version>
                 <executions>
                     <execution>
                         <goals>

--- a/it-selenium/src/test/java/org/apache/roller/selenium/AbstractRollerPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/AbstractRollerPage.java
@@ -17,6 +17,7 @@
  */
 package org.apache.roller.selenium;
 
+import java.time.Duration;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
@@ -35,7 +36,7 @@ public abstract class AbstractRollerPage {
 
     protected void verifyPageTitle(String waitForElementId, String pageTitle) {
 
-        WebDriverWait wait = new WebDriverWait(driver, 10);
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
         wait.until( ExpectedConditions.visibilityOf( driver.findElement(By.id(waitForElementId))));
 
         verifyPageTitle(pageTitle);

--- a/it-selenium/src/test/java/org/apache/roller/selenium/core/RegisterPage.java
+++ b/it-selenium/src/test/java/org/apache/roller/selenium/core/RegisterPage.java
@@ -17,6 +17,7 @@
  */
 package org.apache.roller.selenium.core;
 
+import java.time.Duration;
 import org.apache.roller.selenium.AbstractRollerPage;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
@@ -39,7 +40,7 @@ public class RegisterPage extends AbstractRollerPage {
     public WelcomePage submitUserRegistration() {
         clickById("submit");
 
-        WebDriverWait wait = new WebDriverWait(driver, 10);
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
         wait.until( ExpectedConditions.visibilityOf( driver.findElement(By.id("a_clickHere"))));
         driver.findElement(By.id("a_clickHere")).click();
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ limitations under the License.
         <derby.version>10.11.1.1</derby.version>
         <java-mail.version>1.4.7</java-mail.version>
         <jaxb.version>2.3.1</jaxb.version>
-        <jetty.plugin.version>10.0.16</jetty.plugin.version> <!-- Jetty 11 requires Jakarta package names -->
+        <jetty.plugin.version>10.0.19</jetty.plugin.version> <!-- Jetty 11 requires Jakarta package names -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <roller.version>6.1.2</roller.version>
@@ -62,7 +62,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.11.0</version>
+                    <version>3.12.1</version>
                     <configuration>
                         <release>11</release>
                         <fork>true</fork>
@@ -93,7 +93,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.15.0</version>
+                    <version>2.16.2</version>
                     <configuration>
                         <rulesUri>file:version-rules.xml</rulesUri>
                     </configuration>
@@ -107,7 +107,7 @@ limitations under the License.
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.9.3</version>
+                <version>5.10.1</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
- update project dependencies
- selenium tests don't need an external geckodriver anymore
- update setup-java, checkout and upload-artifact github actions
- fixed rawtype compiler warnings in tests