### PR TITLE
dependency updates

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -39,26 +39,26 @@ limitations under the License.
         <jstl.version>1.2</jstl.version>
         <angular.version>1.7.8</angular.version>
         <ant.version>1.10.14</ant.version>
-        <asm.version>9.6</asm.version>
+        <asm.version>9.7</asm.version>
         <bouncycastle.version>1.70</bouncycastle.version>
-        <commons-validator.version>1.8.0</commons-validator.version>
+        <commons-validator.version>1.9.0</commons-validator.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
-        <commons-codec.version>1.16.0</commons-codec.version>
-        <commons-text.version>1.11.0</commons-text.version>
-        <commons-lang3.version>3.14.0</commons-lang3.version>
-        <eclipse-link.version>4.0.2</eclipse-link.version>
+        <commons-codec.version>1.17.1</commons-codec.version>
+        <commons-text.version>1.12.0</commons-text.version>
+        <commons-lang3.version>3.16.0</commons-lang3.version>
+        <eclipse-link.version>4.0.4</eclipse-link.version>
         <guice.version>7.0.0</guice.version>
-        <log4j2.version>2.22.1</log4j2.version>
-        <lucene.version>9.9.1</lucene.version>
+        <log4j2.version>2.23.1</log4j2.version>
+        <lucene.version>9.11.1</lucene.version>
         <oauth-core.version>20100527</oauth-core.version>
         <maven-war.version>3.4.0</maven-war.version>
-        <maven-surefire.version>3.2.5</maven-surefire.version>
+        <maven-surefire.version>3.5.0</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
         <rome.version>1.19.0</rome.version> <!-- locked in place since next version removes popono -->
-        <slf4j.version>2.0.11</slf4j.version>
-        <spring.version>5.3.31</spring.version>
-        <spring.security.version>5.8.8</spring.security.version>
-        <struts.version>2.5.29</struts.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <spring.version>5.3.39</spring.version>
+        <spring.security.version>5.8.14</spring.security.version>
+        <struts.version>2.5.29</struts.version> <!-- .30+ breaks selenium tests -->
         <velocity.version>2.3</velocity.version>
         <webjars.version>1.6</webjars.version>
         <ws-commons-util.version>1.0.2</ws-commons-util.version>
@@ -273,7 +273,7 @@ limitations under the License.
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery-ui</artifactId>
-            <version>1.13.2</version>
+            <version>1.13.3</version>
         </dependency>
 
         <dependency>
@@ -285,7 +285,7 @@ limitations under the License.
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery-validation</artifactId>
-            <version>1.19.5</version>
+            <version>1.20.0</version>
         </dependency>
 
         <dependency>
@@ -581,14 +581,14 @@ limitations under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.9.0</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>4.0.0</version>
+            <version>5.0.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
@@ -7,10 +7,10 @@ You can override it with your own file via WEB-INF/tiles-def.xml
 
 <script src="<s:url value='/webjars/jquery/3.7.1/jquery.min.js' />"></script>
 
-<script src="<s:url value='/webjars/jquery-ui/1.13.2/jquery-ui.min.js' />"></script>
-<link href="<s:url value='/webjars/jquery-ui/1.13.2/jquery-ui.css' />" rel="stylesheet" />
+<script src="<s:url value='/webjars/jquery-ui/1.13.3/jquery-ui.min.js' />"></script>
+<link href="<s:url value='/webjars/jquery-ui/1.13.3/jquery-ui.css' />" rel="stylesheet" />
 
-<script src="<s:url value='/webjars/jquery-validation/1.19.5/jquery.validate.min.js' />"></script>
+<script src="<s:url value='/webjars/jquery-validation/1.20.0/jquery.validate.min.js' />"></script>
 
 <link href="<s:url value='/webjars/bootstrap/3.4.1/css/bootstrap.min.css' />" rel="stylesheet" />
 <link href="<s:url value='/webjars/bootstrap/3.4.1/css/bootstrap-theme.min.css' />" rel="stylesheet" />

--- a/it-selenium/pom.xml
+++ b/it-selenium/pom.xml
@@ -48,14 +48,14 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.17.0</version>
+            <version>4.23.1</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-firefox-driver</artifactId>
-            <version>4.17.0</version>
+            <version>4.23.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>
@@ -128,7 +128,7 @@
             <!-- Activates integration tests (by default, classes under tests that end with "IT") -->
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ limitations under the License.
         <derby.version>10.11.1.1</derby.version>
         <java-mail.version>1.4.7</java-mail.version>
         <jaxb.version>2.3.1</jaxb.version>
-        <jetty.plugin.version>10.0.19</jetty.plugin.version> <!-- Jetty 11 requires Jakarta package names -->
+        <jetty.plugin.version>10.0.23</jetty.plugin.version> <!-- Jetty 11 requires Jakarta package names -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <roller.version>6.1.4</roller.version>
@@ -62,7 +62,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.12.1</version>
+                    <version>3.13.0</version>
                     <configuration>
                         <release>11</release>
                         <fork>true</fork>
@@ -93,7 +93,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.16.2</version>
+                    <version>2.17.1</version>
                     <configuration>
                         <rulesUri>file:version-rules.xml</rulesUri>
                     </configuration>
@@ -107,7 +107,7 @@ limitations under the License.
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.10.1</version>
+                <version>5.11.0</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
 - asm, spring, lucene, logging, apache commons libs
 - webjars: jquery and jquery-validation
 - build: junit, selenium and other maven plugins

note: spring closed [CVE-2024-38816](https://www.herodevs.com/vulnerability-directory/cve-2024-38816), but it shouldn't affect roller since we don't use `spring-webmvc` or `spring-webflux`