### PR TITLE
Implement one-time-salt use and add comprehensive tests

### DIFF
--- a/app/src/main/java/org/apache/roller/weblogger/pojos/wrapper/WeblogWrapper.java
+++ b/app/src/main/java/org/apache/roller/weblogger/pojos/wrapper/WeblogWrapper.java
@@ -141,9 +141,8 @@ public final class WeblogWrapper {
     }
 
     public String getAnalyticsCode() {
-        return this.pojo.getAnalyticsCode();
+        return HTMLSanitizer.conditionallySanitize(this.pojo.getAnalyticsCode());
     }
-
 
     public Boolean getEmailComments() {
         return this.pojo.getEmailComments();

--- a/app/src/main/java/org/apache/roller/weblogger/ui/core/filters/LoadSaltFilter.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/core/filters/LoadSaltFilter.java
@@ -37,13 +37,14 @@ public class LoadSaltFilter implements Filter {
         throws IOException, ServletException {
 
         HttpServletRequest httpReq = (HttpServletRequest) request;
-        RollerSession rses = RollerSession.getRollerSession(httpReq);
-        String userId = rses != null && rses.getAuthenticatedUser() != null ? rses.getAuthenticatedUser().getId() : "";
-
-        SaltCache saltCache = SaltCache.getInstance();
-        String salt = RandomStringUtils.random(20, 0, 0, true, true, null, new SecureRandom());
-        saltCache.put(salt, userId);
-        httpReq.setAttribute("salt", salt);
+        RollerSession rollerSession = RollerSession.getRollerSession(httpReq);
+        if (rollerSession != null) {
+            String userId = rollerSession.getAuthenticatedUser() != null ? rollerSession.getAuthenticatedUser().getId() : "";
+            SaltCache saltCache = SaltCache.getInstance();
+            String salt = RandomStringUtils.random(20, 0, 0, true, true, null, new SecureRandom());
+            saltCache.put(salt, userId);
+            httpReq.setAttribute("salt", salt);
+        }
 
         chain.doFilter(request, response);
     }

--- a/app/src/main/java/org/apache/roller/weblogger/ui/core/filters/ValidateSaltFilter.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/core/filters/ValidateSaltFilter.java
@@ -51,7 +51,13 @@ public class ValidateSaltFilter implements Filter {
             FilterChain chain) throws IOException, ServletException {
         HttpServletRequest httpReq = (HttpServletRequest) request;
 
-        if ("POST".equals(httpReq.getMethod()) && !isIgnoredURL(httpReq.getServletPath())) {
+        String requestURL = httpReq.getRequestURL().toString();
+        String queryString = httpReq.getQueryString();
+        if (queryString != null) {
+            requestURL += "?" + queryString;
+        }
+
+        if ("POST".equals(httpReq.getMethod()) && !isIgnoredURL(requestURL)) {
             RollerSession rollerSession = RollerSession.getRollerSession(httpReq);
             if (rollerSession != null) {
                 String userId = rollerSession.getAuthenticatedUser() != null ? rollerSession.getAuthenticatedUser().getId() : "";
@@ -88,16 +94,10 @@ public class ValidateSaltFilter implements Filter {
 
     /**
      * Checks if this is an ignored url defined in the salt.ignored.urls property
-     * @param theUrl the the url
+     * @param theUrl the url
      * @return true, if is ignored resource
      */
     private boolean isIgnoredURL(String theUrl) {
-        int i = theUrl.lastIndexOf('/');
-
-        // If it's not a resource then don't ignore it
-        if (i <= 0 || i == theUrl.length() - 1) {
-            return false;
-        }
-        return ignored.contains(theUrl.substring(i + 1));
+        return ignored.contains(theUrl);
     }
 }

--- a/app/src/main/java/org/apache/roller/weblogger/ui/core/filters/ValidateSaltFilter.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/core/filters/ValidateSaltFilter.java
@@ -52,16 +52,24 @@ public class ValidateSaltFilter implements Filter {
         HttpServletRequest httpReq = (HttpServletRequest) request;
 
         if ("POST".equals(httpReq.getMethod()) && !isIgnoredURL(httpReq.getServletPath())) {
-            RollerSession rses = RollerSession.getRollerSession(httpReq);
-            String userId = rses != null && rses.getAuthenticatedUser() != null ? rses.getAuthenticatedUser().getId() : "";
+            RollerSession rollerSession = RollerSession.getRollerSession(httpReq);
+            if (rollerSession != null) {
+                String userId = rollerSession.getAuthenticatedUser() != null ? rollerSession.getAuthenticatedUser().getId() : "";
 
-            String salt = httpReq.getParameter("salt");
-            SaltCache saltCache = SaltCache.getInstance();
-            if (salt == null || !Objects.equals(saltCache.get(salt), userId)) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Valid salt value not found on POST to URL : " + httpReq.getServletPath());
+                String salt = httpReq.getParameter("salt");
+                SaltCache saltCache = SaltCache.getInstance();
+                if (salt == null || !Objects.equals(saltCache.get(salt), userId)) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Valid salt value not found on POST to URL : " + httpReq.getServletPath());
+                    }
+                    throw new ServletException("Security Violation");
                 }
-                throw new ServletException("Security Violation");
+
+                // Remove salt from cache after successful validation
+                saltCache.remove(salt);
+                if (log.isDebugEnabled()) {
+                    log.debug("Salt used and invalidated: " + salt);
+                }
             }
         }
 
@@ -70,8 +78,6 @@ public class ValidateSaltFilter implements Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-
-        // Construct our list of ignored urls
         String urls = WebloggerConfig.getProperty("salt.ignored.urls");
         ignored = Set.of(StringUtils.stripAll(StringUtils.split(urls, ",")));
     }

--- a/app/src/main/java/org/apache/roller/weblogger/ui/struts2/editor/WeblogConfig.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/struts2/editor/WeblogConfig.java
@@ -61,6 +61,8 @@ public class WeblogConfig extends UIAction {
     
     // list of available plugins
     private List<WeblogEntryPlugin> pluginsList = Collections.emptyList();
+
+    private boolean weblogAdminsUntrusted = WebloggerRuntimeConfig.getBooleanProperty("weblogAdminsUntrusted");
     
     
     public WeblogConfig() {
@@ -71,7 +73,7 @@ public class WeblogConfig extends UIAction {
 
     @Override
     public void myPrepare() {
-        
+
         try {
             WeblogEntryManager wmgr = WebloggerFactory.getWeblogger().getWeblogEntryManager();
             
@@ -231,5 +233,8 @@ public class WeblogConfig extends UIAction {
     public void setPluginsList(List<WeblogEntryPlugin> pluginsList) {
         this.pluginsList = pluginsList;
     }
-    
+
+    public boolean getWeblogAdminsUntrusted() {
+        return weblogAdminsUntrusted;
+    }
 }

--- a/app/src/main/java/org/apache/roller/weblogger/ui/struts2/editor/WeblogConfig.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/struts2/editor/WeblogConfig.java
@@ -29,6 +29,7 @@ import org.apache.roller.weblogger.business.plugins.PluginManager;
 import org.apache.roller.weblogger.business.WebloggerFactory;
 import org.apache.roller.weblogger.business.WeblogEntryManager;
 import org.apache.roller.weblogger.business.plugins.entry.WeblogEntryPlugin;
+import org.apache.roller.weblogger.config.WebloggerConfig;
 import org.apache.roller.weblogger.config.WebloggerRuntimeConfig;
 import org.apache.roller.weblogger.pojos.Weblog;
 import org.apache.roller.weblogger.pojos.WeblogCategory;
@@ -62,7 +63,7 @@ public class WeblogConfig extends UIAction {
     // list of available plugins
     private List<WeblogEntryPlugin> pluginsList = Collections.emptyList();
 
-    private boolean weblogAdminsUntrusted = WebloggerRuntimeConfig.getBooleanProperty("weblogAdminsUntrusted");
+    private final boolean weblogAdminsUntrusted = WebloggerConfig.getBooleanProperty("weblogAdminsUntrusted");
     
     
     public WeblogConfig() {
@@ -90,10 +91,7 @@ public class WeblogConfig extends UIAction {
             // set plugins list
             PluginManager ppmgr = WebloggerFactory.getWeblogger().getPluginManager();
             Map<String, WeblogEntryPlugin> pluginsMap = ppmgr.getWeblogEntryPlugins(getActionWeblog());
-            List<WeblogEntryPlugin> plugins = new ArrayList<>();
-            for (WeblogEntryPlugin entryPlugin : pluginsMap.values()) {
-                plugins.add(entryPlugin);
-            }
+            List<WeblogEntryPlugin> plugins = new ArrayList<>(pluginsMap.values());
 
             // sort
             setPluginsList(plugins);

--- a/app/src/main/resources/ApplicationResources.properties
+++ b/app/src/main/resources/ApplicationResources.properties
@@ -1759,6 +1759,7 @@ websiteSettings.formatting=Formatting
 websiteSettings.spamPrevention=Spam Prevention
 websiteSettings.ignoreUrls=List of words and regex expressions listed one per \
 line to be added to the banned words list used to check comments, trackbacks and referrers.
+websiteSettings.bannedWordsList=Words banned in comments (regex allowed)
 websiteSettings.acceptedBannedwordslist=Accepted {0} string and {1} regex banned-words list rules
 websiteSettings.error.processingBannedwordslist=Error processing banned-words list: {0}
 

--- a/app/src/main/webapp/WEB-INF/jsps/editor/WeblogConfig.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/WeblogConfig.jsp
@@ -130,7 +130,7 @@
     <h3><s:text name="websiteSettings.spamPrevention"/></h3>
 
     <s:textarea name="bean.bannedwordslist" rows="7" cols="40"
-                label="%{getText('websiteSettings.analyticsTrackingCode')}"/>
+                label="%{getText('websiteSettings.bannedWordsList')}"/>
 
     <%-- ***** Web analytics settings ***** --%>
 

--- a/app/src/main/webapp/WEB-INF/jsps/editor/WeblogConfig.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/WeblogConfig.jsp
@@ -134,7 +134,7 @@
 
     <%-- ***** Web analytics settings ***** --%>
 
-    <s:if test="getBooleanProp('analytics.code.override.allowed')">
+    <s:if test="getBooleanProp('analytics.code.override.allowed') && !weblogAdminsUntrusted">
         <h3><s:text name="configForm.webAnalytics"/></h3>
 
         <s:textarea name="bean.analyticsCode" rows="10" cols="70"

--- a/app/src/test/java/org/apache/roller/weblogger/ui/core/filters/LoadSaltFilterTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/core/filters/LoadSaltFilterTest.java
@@ -1,0 +1,88 @@
+package org.apache.roller.weblogger.ui.core.filters;
+
+import org.apache.roller.weblogger.pojos.User;
+import org.apache.roller.weblogger.ui.core.RollerSession;
+import org.apache.roller.weblogger.ui.rendering.util.cache.SaltCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.mockito.Mockito.*;
+
+public class LoadSaltFilterTest {
+
+    private LoadSaltFilter filter;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    @Mock
+    private RollerSession rollerSession;
+
+    @Mock
+    private SaltCache saltCache;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        filter = new LoadSaltFilter();
+    }
+
+    @Test
+    public void testDoFilterGeneratesSalt() throws Exception {
+        try (MockedStatic<RollerSession> mockedRollerSession = mockStatic(RollerSession.class);
+             MockedStatic<SaltCache> mockedSaltCache = mockStatic(SaltCache.class)) {
+
+            mockedRollerSession.when(() -> RollerSession.getRollerSession(request)).thenReturn(rollerSession);
+            mockedSaltCache.when(SaltCache::getInstance).thenReturn(saltCache);
+
+            when(rollerSession.getAuthenticatedUser()).thenReturn(new TestUser("userId"));
+
+            filter.doFilter(request, response, chain);
+
+            verify(request).setAttribute(eq("salt"), anyString());
+            verify(saltCache).put(anyString(), eq("userId"));
+            verify(chain).doFilter(request, response);
+        }
+    }
+
+    @Test
+    public void testDoFilterWithNullRollerSession() throws Exception {
+        try (MockedStatic<RollerSession> mockedRollerSession = mockStatic(RollerSession.class);
+             MockedStatic<SaltCache> mockedSaltCache = mockStatic(SaltCache.class)) {
+
+            mockedRollerSession.when(() -> RollerSession.getRollerSession(request)).thenReturn(null);
+            mockedSaltCache.when(SaltCache::getInstance).thenReturn(saltCache);
+
+            filter.doFilter(request, response, chain);
+
+            verify(request, never()).setAttribute(eq("salt"), anyString());
+            verify(saltCache, never()).put(anyString(), anyString());
+            verify(chain).doFilter(request, response);
+        }
+    }
+
+    private static class TestUser extends User {
+        private final String id;
+
+        TestUser(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+    }
+}

--- a/app/src/test/java/org/apache/roller/weblogger/ui/core/filters/ValidateSaltFilterTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/core/filters/ValidateSaltFilterTest.java
@@ -64,7 +64,6 @@ public class ValidateSaltFilterTest {
             mockedSaltCache.when(SaltCache::getInstance).thenReturn(saltCache);
 
             when(request.getMethod()).thenReturn("POST");
-            when(request.getServletPath()).thenReturn("/someurl");
             when(request.getParameter("salt")).thenReturn("validSalt");
             when(saltCache.get("validSalt")).thenReturn("userId");
             when(rollerSession.getAuthenticatedUser()).thenReturn(new TestUser("userId"));
@@ -87,7 +86,6 @@ public class ValidateSaltFilterTest {
             mockedSaltCache.when(SaltCache::getInstance).thenReturn(saltCache);
 
             when(request.getMethod()).thenReturn("POST");
-            when(request.getServletPath()).thenReturn("/someurl");
             when(request.getParameter("salt")).thenReturn("invalidSalt");
             when(saltCache.get("invalidSalt")).thenReturn(null);
             StringBuffer requestURL = new StringBuffer("https://example.com/app/ignoredurl");
@@ -108,7 +106,6 @@ public class ValidateSaltFilterTest {
             mockedSaltCache.when(SaltCache::getInstance).thenReturn(saltCache);
 
             when(request.getMethod()).thenReturn("POST");
-            when(request.getServletPath()).thenReturn("/someurl");
             when(request.getParameter("salt")).thenReturn("validSalt");
             when(saltCache.get("validSalt")).thenReturn("differentUserId");
             when(rollerSession.getAuthenticatedUser()).thenReturn(new TestUser("userId"));
@@ -130,7 +127,6 @@ public class ValidateSaltFilterTest {
             mockedSaltCache.when(SaltCache::getInstance).thenReturn(saltCache);
 
             when(request.getMethod()).thenReturn("POST");
-            when(request.getServletPath()).thenReturn("/someurl");
             when(request.getParameter("salt")).thenReturn("validSalt");
             when(saltCache.get("validSalt")).thenReturn("");
             StringBuffer requestURL = new StringBuffer("https://example.com/app/ignoredurl");

--- a/app/src/test/java/org/apache/roller/weblogger/ui/core/filters/ValidateSaltFilterTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/core/filters/ValidateSaltFilterTest.java
@@ -1,0 +1,144 @@
+package org.apache.roller.weblogger.ui.core.filters;
+
+import org.apache.roller.weblogger.pojos.User;
+import org.apache.roller.weblogger.ui.core.RollerSession;
+import org.apache.roller.weblogger.ui.rendering.util.cache.SaltCache;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+public class ValidateSaltFilterTest {
+
+    private ValidateSaltFilter filter;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    @Mock
+    private RollerSession rollerSession;
+
+    @Mock
+    private SaltCache saltCache;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        filter = new ValidateSaltFilter();
+    }
+
+    @Test
+    public void testDoFilterWithGetMethod() throws Exception {
+        when(request.getMethod()).thenReturn("GET");
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    public void testDoFilterWithPostMethodAndValidSalt() throws Exception {
+        try (MockedStatic<RollerSession> mockedRollerSession = mockStatic(RollerSession.class);
+             MockedStatic<SaltCache> mockedSaltCache = mockStatic(SaltCache.class)) {
+
+            mockedRollerSession.when(() -> RollerSession.getRollerSession(request)).thenReturn(rollerSession);
+            mockedSaltCache.when(SaltCache::getInstance).thenReturn(saltCache);
+
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getServletPath()).thenReturn("/someurl");
+            when(request.getParameter("salt")).thenReturn("validSalt");
+            when(saltCache.get("validSalt")).thenReturn("userId");
+            when(rollerSession.getAuthenticatedUser()).thenReturn(new TestUser("userId"));
+
+            filter.doFilter(request, response, chain);
+
+            verify(chain).doFilter(request, response);
+            verify(saltCache).remove("validSalt");
+        }
+    }
+
+    @Test
+    public void testDoFilterWithPostMethodAndInvalidSalt() throws Exception {
+        try (MockedStatic<RollerSession> mockedRollerSession = mockStatic(RollerSession.class);
+             MockedStatic<SaltCache> mockedSaltCache = mockStatic(SaltCache.class)) {
+
+            mockedRollerSession.when(() -> RollerSession.getRollerSession(request)).thenReturn(rollerSession);
+            mockedSaltCache.when(SaltCache::getInstance).thenReturn(saltCache);
+
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getServletPath()).thenReturn("/someurl");
+            when(request.getParameter("salt")).thenReturn("invalidSalt");
+            when(saltCache.get("invalidSalt")).thenReturn(null);
+
+            assertThrows(ServletException.class, () -> {
+                filter.doFilter(request, response, chain);
+            });
+        }
+    }
+
+    @Test
+    public void testDoFilterWithPostMethodAndMismatchedUserId() throws Exception {
+        try (MockedStatic<RollerSession> mockedRollerSession = mockStatic(RollerSession.class);
+             MockedStatic<SaltCache> mockedSaltCache = mockStatic(SaltCache.class)) {
+
+            mockedRollerSession.when(() -> RollerSession.getRollerSession(request)).thenReturn(rollerSession);
+            mockedSaltCache.when(SaltCache::getInstance).thenReturn(saltCache);
+
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getServletPath()).thenReturn("/someurl");
+            when(request.getParameter("salt")).thenReturn("validSalt");
+            when(saltCache.get("validSalt")).thenReturn("differentUserId");
+            when(rollerSession.getAuthenticatedUser()).thenReturn(new TestUser("userId"));
+
+            assertThrows(ServletException.class, () -> {
+                filter.doFilter(request, response, chain);
+            });
+        }
+    }
+
+    @Test
+    public void testDoFilterWithPostMethodAndNullRollerSession() throws Exception {
+        try (MockedStatic<RollerSession> mockedRollerSession = mockStatic(RollerSession.class);
+             MockedStatic<SaltCache> mockedSaltCache = mockStatic(SaltCache.class)) {
+
+            mockedRollerSession.when(() -> RollerSession.getRollerSession(request)).thenReturn(null);
+            mockedSaltCache.when(SaltCache::getInstance).thenReturn(saltCache);
+
+            when(request.getMethod()).thenReturn("POST");
+            when(request.getServletPath()).thenReturn("/someurl");
+            when(request.getParameter("salt")).thenReturn("validSalt");
+            when(saltCache.get("validSalt")).thenReturn("");
+
+            filter.doFilter(request, response, chain);
+
+            verify(saltCache, never()).remove("validSalt");
+        }
+    }
+    private static class TestUser extends User {
+        private final String id;
+
+        TestUser(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public String getId() {
+            return id;
+        }
+    }
+}


### PR DESCRIPTION
This PR implements one-time use salts, improves URL matching for ignored URLs, and enhances security in ValidateSaltFilter and LoadSaltFilter. It also adds comprehensive unit tests for both filters to ensure proper functionality and edge case handling. The changes include:

* Implementing one-time use salts by removing them from the cache after validation
* Improving URL matching to consider full URLs including query parameters
* Enhancing security checks in ValidateSaltFilter
* Adding robust unit tests for both filters
* Refactoring code for better readability and maintainability