### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11', '17', '21' ]
+        java: [ '11', '17', '21', '23' ]
 
     steps:
       - name: Set up JDK ${{ matrix.java }} 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -38,28 +38,28 @@ limitations under the License.
         <java-activation.version>1.2.0</java-activation.version>
         <jstl.version>1.2</jstl.version>
         <angular.version>1.7.8</angular.version>
-        <ant.version>1.10.14</ant.version>
-        <asm.version>9.7</asm.version>
+        <ant.version>1.10.15</ant.version>
+        <asm.version>9.7.1</asm.version>
         <bouncycastle.version>1.70</bouncycastle.version>
         <commons-validator.version>1.9.0</commons-validator.version>
-        <commons-beanutils.version>1.9.4</commons-beanutils.version>
-        <commons-codec.version>1.17.1</commons-codec.version>
-        <commons-text.version>1.12.0</commons-text.version>
-        <commons-lang3.version>3.16.0</commons-lang3.version>
-        <eclipse-link.version>4.0.4</eclipse-link.version>
+        <commons-beanutils.version>1.10.0</commons-beanutils.version>
+        <commons-codec.version>1.18.0</commons-codec.version>
+        <commons-text.version>1.13.0</commons-text.version>
+        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <eclipse-link.version>4.0.5</eclipse-link.version>
         <guice.version>7.0.0</guice.version>
-        <log4j2.version>2.23.1</log4j2.version>
-        <lucene.version>9.11.1</lucene.version>
+        <log4j2.version>2.24.3</log4j2.version>
+        <lucene.version>9.12.1</lucene.version> <!-- lucene 10 requires JDK 21 -->
         <oauth-core.version>20100527</oauth-core.version>
         <maven-war.version>3.4.0</maven-war.version>
-        <maven-surefire.version>3.5.0</maven-surefire.version>
+        <maven-surefire.version>3.5.2</maven-surefire.version>
         <maven-antrun.version>1.0b3</maven-antrun.version>
         <rome.version>1.19.0</rome.version> <!-- locked in place since next version removes popono -->
         <slf4j.version>2.0.16</slf4j.version>
         <spring.version>5.3.39</spring.version>
         <spring.security.version>5.8.14</spring.security.version>
         <struts.version>2.5.29</struts.version> <!-- .30+ breaks selenium tests -->
-        <velocity.version>2.3</velocity.version>
+        <velocity.version>2.4.1</velocity.version>
         <webjars.version>1.6</webjars.version>
         <ws-commons-util.version>1.0.2</ws-commons-util.version>
         <xmlrpc-version>3.1.3</xmlrpc-version>
@@ -273,7 +273,7 @@ limitations under the License.
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery-ui</artifactId>
-            <version>1.13.3</version>
+            <version>1.14.1</version>
         </dependency>
 
         <dependency>
@@ -581,14 +581,14 @@ limitations under the License.
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.12.0</version>
+            <version>5.15.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.instancio</groupId>
             <artifactId>instancio-junit</artifactId>
-            <version>5.0.1</version>
+            <version>5.3.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -795,7 +795,7 @@ limitations under the License.
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>

--- a/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
@@ -7,8 +7,8 @@ You can override it with your own file via WEB-INF/tiles-def.xml
 
 <script src="<s:url value='/webjars/jquery/3.7.1/jquery.min.js' />"></script>
 
-<script src="<s:url value='/webjars/jquery-ui/1.13.3/jquery-ui.min.js' />"></script>
-<link href="<s:url value='/webjars/jquery-ui/1.13.3/jquery-ui.css' />" rel="stylesheet" />
+<script src="<s:url value='/webjars/jquery-ui/1.14.1/jquery-ui.min.js' />"></script>
+<link href="<s:url value='/webjars/jquery-ui/1.14.1/jquery-ui.css' />" rel="stylesheet" />
 
 <script src="<s:url value='/webjars/jquery-validation/1.20.0/jquery.validate.min.js' />"></script>
 

--- a/it-selenium/pom.xml
+++ b/it-selenium/pom.xml
@@ -48,14 +48,14 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>4.23.1</version>
+            <version>4.28.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-firefox-driver</artifactId>
-            <version>4.23.1</version>
+            <version>4.28.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>
@@ -128,7 +128,7 @@
             <!-- Activates integration tests (by default, classes under tests that end with "IT") -->
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ limitations under the License.
         <derby.version>10.11.1.1</derby.version>
         <java-mail.version>1.4.7</java-mail.version>
         <jaxb.version>2.3.1</jaxb.version>
-        <jetty.plugin.version>10.0.23</jetty.plugin.version> <!-- Jetty 11 requires Jakarta package names -->
+        <jetty.plugin.version>10.0.24</jetty.plugin.version> <!-- Jetty 11 requires Jakarta package names -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <roller.version>6.1.4</roller.version>
@@ -93,7 +93,7 @@ limitations under the License.
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.17.1</version>
+                    <version>2.18.0</version>
                     <configuration>
                         <rulesUri>file:version-rules.xml</rulesUri>
                     </configuration>
@@ -107,7 +107,7 @@ limitations under the License.
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.11.0</version>
+                <version>5.11.4</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
 - only point releases
 - all tests pass on JDK 24
 - ~unit tests would pass on JDK 24 if bytebuddy would be bumped (not done since transitive mockito dependency, this should resolve itself automatically)~
 - added JDK 23 to test matrix

haven't deployed this version yet. leaving it as draft till then