### PR TITLE
Update install guide with working JavaMail download links

### DIFF
--- a/docs/roller-install-guide.adoc
+++ b/docs/roller-install-guide.adoc
@@ -479,7 +479,7 @@ password in 'mail/Session' Resource.
 ----
 
 The Java mail properties listed above are defined here:
-https://javamail.java.net/nonav/docs/api/com/sun/mail/smtp/package-summary.html.
+https://eclipse-ee4j.github.io/mail/docs/api/com/sun/mail/smtp/package-summary.html.
 Note the email account defined above will appear in the "From:" line
 of notification email messages sent to blog owners (and, if they select
 "Notify me of further comments", blog commenters) so take care not to
@@ -523,9 +523,12 @@ subsystem will be able to find and use them. Download them from your
 database vendor/provider and place them in Tomcat’s _lib_ directory.
 * **Java Mail and Activation. **Tomcat does not include the Java Mail
 and Activation jars. Even if you do not plan to use email features, you
-must download those jars and place them in Tomcat’s classpath. Download
-them from Oracle (https://java.net/projects/javamail/pages/Home) and
-place them in Tomcat’s _lib_ directory.
+must download those jars and place them in Tomcat’s classpath because
+Roller uses the JavaMail API for email address validation in its core
+code. Download them from Maven Central and place them in Tomcat’s _lib_
+directory:
+** https://repo1.maven.org/maven2/com/sun/mail/jakarta.mail/1.6.7/jakarta.mail-1.6.7.jar[jakarta.mail-1.6.7.jar]
+** https://repo1.maven.org/maven2/com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar[jakarta.activation-1.2.2.jar]
 
 === Tomcat: Set URI Encoding
 


### PR DESCRIPTION
## Summary

- Replaced the dead JavaMail download link (`https://java.net/projects/javamail/pages/Home`) with direct Maven Central links for `jakarta.mail-1.6.7.jar` and `jakarta.activation-1.2.2.jar`
- Added an explanation for *why* the JavaMail JARs are required even without email features: Roller uses `javax.mail.internet.InternetAddress` for email address validation in core code (`Utilities.java`), so the dependency is loaded at runtime regardless of mail configuration
- Updated the SMTP Javadoc link from `javamail.java.net` to the current Eclipse project URL

## Context

Without the JavaMail JARs in Tomcat's `lib/`, Roller throws a 500 error on login with `ClassNotFoundException: javax.mail.internet.AddressException`. The install guide already says to add these JARs, but the download link has been dead since java.net was shut down, making it easy to skip or miss this step.