### PR TITLE
Use double-quoted attributes in media file links inserted into new entries

### DIFF
--- a/app/src/main/java/org/apache/roller/weblogger/ui/struts2/editor/EntryAddWithMediaFile.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/struts2/editor/EntryAddWithMediaFile.java
@@ -76,14 +76,14 @@ public class EntryAddWithMediaFile extends MediaFileBase {
 
                     if (mediaFile.isImageFile()) {
                         link = "<p>" + mediaFile.getName() + "</p>";
-                        link += "<a href='<url>'><img src='<urlt>' alt='<name>' width='<width>' height='<height>'></img></a>";
+                        link += "<a href=\"<url>\"><img src=\"<urlt>\" alt=\"<name>\" width=\"<width>\" height=\"<height>\" /></a>";
                         link = link.replace("<url>", mediaFile.getPermalink())
                                    .replace("<urlt>", mediaFile.getThumbnailURL())
                                    .replace("<name>", mediaFile.getName())
                                    .replace("<width>", ""+mediaFile.getThumbnailWidth())
                                    .replace("<height>", ""+mediaFile.getThumbnailHeight());
                     } else {
-                        link = "<a href='<url>'><name></a> (<size> bytes, <type>)";
+                        link = "<a href=\"<url>\"><name></a> (<size> bytes, <type>)";
                         link = link.replace("<url>", mediaFile.getPermalink())
                                    .replace("<name>", mediaFile.getName())
                                    .replace("<size>",""+mediaFile.getLength())
@@ -97,7 +97,7 @@ public class EntryAddWithMediaFile extends MediaFileBase {
                 sb.append("<p>")
                   .append(getText("mediaFileEdit.includesEnclosure"))
                   .append("<br />")
-                  .append("<a href='" + bean.getEnclosureURL() + "'>")
+                  .append("<a href=\"" + bean.getEnclosureURL() + "\">")
                   .append(bean.getEnclosureURL())
                   .append("</a></p>");
             }


### PR DESCRIPTION
The "create a post from your uploaded files" flow builds its image and enclosure markup with single-quoted attributes and an invalid closing </img> tag, and the resulting image does not render after publishing. The media chooser on the entry editor inserts the same link with double quotes and a self-closing img tag, and that form works, so this flow now matches it.

Reported by Greg Huber on dev@roller while testing the ROL-2183 branch; the bug exists on master independently of that work.