### PR TITLE
Move authoring UI inline JS handlers to data attributes

### DIFF
--- a/app/src/main/java/org/apache/roller/weblogger/ui/struts2/ajax/ThemeDataServlet.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/struts2/ajax/ThemeDataServlet.java
@@ -17,6 +17,7 @@
  */
 package org.apache.roller.weblogger.ui.struts2.ajax;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.roller.weblogger.WebloggerException;
 import org.apache.roller.weblogger.business.WebloggerFactory;
 import org.apache.roller.weblogger.business.themes.SharedTheme;
@@ -80,17 +81,21 @@ public class ThemeDataServlet extends HttpServlet {
         }
         for (Iterator<SharedTheme> it = themes.iterator(); it.hasNext();) {
             SharedTheme theme = it.next();
+            // Theme metadata comes from theme.xml, which an operator can edit
+            // or install; escape it so a quote or newline cannot break out of
+            // the string and produce malformed JSON.
             pw.print("    { \"id\" : \"");
-            pw.print(theme.getId());
+            pw.print(StringEscapeUtils.escapeJson(theme.getId()));
             pw.print("\", ");
             pw.print("\"name\" : \"");
-            pw.print(theme.getName());
+            pw.print(StringEscapeUtils.escapeJson(theme.getName()));
             pw.print("\", ");
             pw.print("\"description\" : \"");
-            pw.print(theme.getDescription());
+            pw.print(StringEscapeUtils.escapeJson(theme.getDescription()));
             pw.print("\", ");
             pw.print("\"previewPath\" : \"");
-            pw.print("/themes" + "/" + theme.getId() + "/" + theme.getPreviewImage().getPath());
+            pw.print(StringEscapeUtils.escapeJson(
+                    "/themes" + "/" + theme.getId() + "/" + theme.getPreviewImage().getPath()));
             pw.print("\" }");
             if (it.hasNext()) {
                 pw.println(", ");

--- a/app/src/main/webapp/WEB-INF/jsps/core/CreateWeblog.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/core/CreateWeblog.jsp
@@ -115,7 +115,7 @@
     function previewImage(themeId) {
         $.ajax({ url: "<s:property value='siteURL' />/roller-ui/authoring/themedata",
             data: {theme:themeId}, success: function(data) {
-                $('#themedescription').html(data.description);
+                $('#themedescription').text(data.description);
                 $('#themeThumbnail').attr('src','<s:property value="siteURL" />' + data.previewPath);
             }
         });

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Bookmarks.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Bookmarks.jsp
@@ -706,8 +706,7 @@ We used to call them Bookmarks and Folders, now we call them Blogroll links and 
     }
 
 
-    // Author-supplied values travel in data attributes and are read back as
-    // text rather than being interpolated into inline handlers.
+    // Values come from data-* attributes and are bound via delegated listeners.
     $(document).on('click', '.bookmark-edit-link', function (event) {
         event.preventDefault();
         editBookmark($(this).attr('data-bookmark-id'),

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Bookmarks.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Bookmarks.jsp
@@ -143,13 +143,13 @@ We used to call them Bookmarks and Folders, now we call them Blogroll links and 
 
                     <td align="center">
 
-                        <a href="#" onclick="editBookmark(
-                                '<s:property value="#bookmark.id"/>',
-                                '<s:property value="#bookmark.name"/>',
-                                '<s:property value="#bookmark.url"/>',
-                                '<s:property value="#bookmark.feedUrl"/>',
-                                '<s:property value="#bookmark.description"/>',
-                                '<s:property value="#bookmark.image"/>' )">
+                        <a href="#" class="bookmark-edit-link"
+                           data-bookmark-id="<s:property value="#bookmark.id"/>"
+                           data-bookmark-name="<s:property value="#bookmark.name"/>"
+                           data-bookmark-url="<s:property value="#bookmark.url"/>"
+                           data-bookmark-feed-url="<s:property value="#bookmark.feedUrl"/>"
+                           data-bookmark-description="<s:property value="#bookmark.description"/>"
+                           data-bookmark-image="<s:property value="#bookmark.image"/>">
                             <span class="glyphicon glyphicon-edit"></span>
                         </a>
 
@@ -338,7 +338,7 @@ We used to call them Bookmarks and Folders, now we call them Blogroll links and 
 
     function confirmDeleteFolder() {
         $('#boomarks_delete_folder_folderId').val($('#bookmarks_folderId:first').val());
-        $('#deleteBlogrollName').html('<s:property value="%{folder.name}"/>');
+        $('#deleteBlogrollName').text('<s:property value="%{folder.name}"/>');
         $('#delete-blogroll-modal').modal({show: true});
     }
 
@@ -700,11 +700,23 @@ We used to call them Bookmarks and Folders, now we call them Blogroll links and 
         $('#bookmarkEdit_bean_image:first').val('');
         $('#bookmarkEdit_bean_feedUrl:first').val('');
 
-        $('#subtitle_folder_name:first').html(originalName);
+        $('#subtitle_folder_name:first').text(originalName);
 
         $('#addedit-bookmark-modal').modal({show: true});
     }
 
+
+    // Author-supplied values travel in data attributes and are read back as
+    // text rather than being interpolated into inline handlers.
+    $(document).on('click', '.bookmark-edit-link', function (event) {
+        event.preventDefault();
+        editBookmark($(this).attr('data-bookmark-id'),
+                $(this).attr('data-bookmark-name'),
+                $(this).attr('data-bookmark-url'),
+                $(this).attr('data-bookmark-feed-url'),
+                $(this).attr('data-bookmark-description'),
+                $(this).attr('data-bookmark-image'));
+    });
 
     function editBookmark(id, name, url, feedUrl, description, image) {
 
@@ -725,7 +737,7 @@ We used to call them Bookmarks and Folders, now we call them Blogroll links and 
         $('#bookmarkEdit_bean_description:first').val(description);
         $('#bookmarkEdit_bean_image:first').val(image);
 
-        $('#subtitle_folder_name:first').html(originalName);
+        $('#subtitle_folder_name:first').text(originalName);
 
         $('#addedit-bookmark-modal').modal({show: true});
     }
@@ -770,7 +782,7 @@ We used to call them Bookmarks and Folders, now we call them Blogroll links and 
             elem.removeClass("alert-info");
             elem.removeClass("alert-danger");
             elem.addClass("alert-success");
-            elem.html(message);
+            elem.text(message);
 
         } else {
             saveBookmarkButton.attr("disabled", true);
@@ -789,7 +801,7 @@ We used to call them Bookmarks and Folders, now we call them Blogroll links and 
             elem.removeClass("alert-info");
             elem.removeClass("alert-success");
             elem.addClass("alert-danger");
-            elem.html(message);
+            elem.text(message);
         }
     }
 

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Bookmarks.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Bookmarks.jsp
@@ -131,7 +131,7 @@ We used to call them Bookmarks and Folders, now we call them Blogroll links and 
 
                     <td>
                         <s:if test="#bookmark.url != null">
-                            <a href='<s:property value="#bookmark.url" />' target='_blank'>
+                            <a href="<s:property value="#bookmark.url" />" target="_blank">
                                 <str:truncateNicely lower="70" upper="90">
                                     <s:property value="#bookmark.url"/>
                                 </str:truncateNicely>
@@ -338,7 +338,7 @@ We used to call them Bookmarks and Folders, now we call them Blogroll links and 
 
     function confirmDeleteFolder() {
         $('#boomarks_delete_folder_folderId').val($('#bookmarks_folderId:first').val());
-        $('#deleteBlogrollName').text('<s:property value="%{folder.name}"/>');
+        $('#deleteBlogrollName').text($('#deleteBlogrollName').data('folder-name'));
         $('#delete-blogroll-modal').modal({show: true});
     }
 
@@ -565,7 +565,8 @@ We used to call them Bookmarks and Folders, now we call them Blogroll links and 
 
                 <div class="modal-body">
                     <s:text name="blogrollDeleteOK.areYouSure" />
-                    <span id="deleteBlogrollName"></span>?
+                    <span id="deleteBlogrollName"
+                          data-folder-name="<s:property value="%{folder.name}"/>"></span>?
                 </div>
 
                 <div class="modal-footer">

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Categories.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Categories.jsp
@@ -55,11 +55,11 @@
                         <s:set var="categoryName"  value="#category.name" />
                         <s:set var="categoryDesc"  value="#category.description" />
                         <s:set var="categoryImage" value="#category.image" />
-                        <a href="#" onclick="showCategoryEditModal(
-                                '<s:property value="categoryId" />',
-                                '<s:property value="categoryName"/>',
-                                '<s:property value="categoryDesc"/>',
-                                '<s:property value="categoryImage"/>' )">
+                        <a href="#" class="category-edit-link"
+                           data-category-id="<s:property value="categoryId" />"
+                           data-category-name="<s:property value="categoryName"/>"
+                           data-category-desc="<s:property value="categoryDesc"/>"
+                           data-category-image="<s:property value="categoryImage"/>">
                             <span class="glyphicon glyphicon-edit"></span>
                         </a>
 
@@ -71,10 +71,10 @@
                             <s:set var="categoryId"    value="#category.id" />
                             <s:set var="categoryName"  value="#category.name" />
                             <s:set var="categoryInUse" value="#category.inUse.toString()" />
-                            <a href="#" onclick="showCategoryDeleteModal(
-                                    '<s:property value="categoryId" />',
-                                    '<s:property value="categoryName" />',
-                                    <s:property value="categoryInUse"/> )" >
+                            <a href="#" class="category-delete-link"
+                               data-category-id="<s:property value="categoryId" />"
+                               data-category-name="<s:property value="categoryName" />"
+                               data-category-in-use="<s:property value="categoryInUse"/>">
                                 <span class="glyphicon glyphicon-trash"></span>
                             </a>
 
@@ -288,7 +288,7 @@
     function showCategoryDeleteModal( id, name, inUse ) {
         $('#categoryRemove_removeId').val(id);
         $('#categoryEdit_bean_name').val(name);
-        $('#category-name').html(name);
+        $('#category-name').text(name);
         if ( inUse ) {
             $('#category-in-use').css('display','block');
             $('#category-emtpy').css('display', 'none');
@@ -301,14 +301,15 @@
     }
 
     function populateCategorySelect(removeId) {
-        const allCategories = [];
-
-        <s:iterator value="allCategories" var="category">
-        allCategories.push({
-            id: '<s:property value="#category.id"/>',
-            name: '<s:property value="#category.name"/>'
-        });
-        </s:iterator>
+        // Category names are author-supplied. They are rendered into data
+        // attributes below and read back as text here, so no name is ever
+        // parsed as JavaScript.
+        const allCategories = $('#category-option-data .category-option').map(function () {
+            return {
+                id: $(this).attr('data-category-id'),
+                name: $(this).attr('data-category-name')
+            };
+        }).get();
 
         const select = $('#categoryRemove_targetCategoryId');
         select.empty();
@@ -319,4 +320,31 @@
         });
     }
 
+    // Author-supplied values travel in data attributes and are read back as
+    // text rather than being interpolated into inline handlers.
+    $(document).on('click', '.category-edit-link', function (event) {
+        event.preventDefault();
+        showCategoryEditModal($(this).attr('data-category-id'),
+                $(this).attr('data-category-name'),
+                $(this).attr('data-category-desc'),
+                $(this).attr('data-category-image'));
+    });
+
+    $(document).on('click', '.category-delete-link', function (event) {
+        event.preventDefault();
+        showCategoryDeleteModal($(this).attr('data-category-id'),
+                $(this).attr('data-category-name'),
+                $(this).attr('data-category-in-use') === 'true');
+    });
+
 </script>
+
+<%-- Source data for the "move entries to" select, carried as escaped
+     attributes rather than generated JavaScript literals. --%>
+<div id="category-option-data" style="display:none">
+    <s:iterator value="allCategories" var="category">
+        <span class="category-option"
+              data-category-id="<s:property value="#category.id"/>"
+              data-category-name="<s:property value="#category.name"/>"></span>
+    </s:iterator>
+</div>

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Categories.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Categories.jsp
@@ -320,8 +320,7 @@
         });
     }
 
-    // Author-supplied values travel in data attributes and are read back as
-    // text rather than being interpolated into inline handlers.
+    // Values come from data-* attributes and are bound via delegated listeners.
     $(document).on('click', '.category-edit-link', function (event) {
         event.preventDefault();
         showCategoryEditModal($(this).attr('data-category-id'),

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Categories.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Categories.jsp
@@ -291,10 +291,10 @@
         $('#category-name').text(name);
         if ( inUse ) {
             $('#category-in-use').css('display','block');
-            $('#category-emtpy').css('display', 'none');
+            $('#category-empty').css('display', 'none');
         } else {
             $('#category-in-use').css('display', 'none');
-            $('#category-emtpy').css('display', 'block');
+            $('#category-empty').css('display', 'block');
         }
         populateCategorySelect(id);
         $('#delete-category-modal').modal({show: true});
@@ -304,7 +304,7 @@
         // Category names are author-supplied. They are rendered into data
         // attributes below and read back as text here, so no name is ever
         // parsed as JavaScript.
-        const allCategories = $('#category-option-data .category-option').map(function () {
+        const allCategories = $('.category-delete-link').map(function () {
             return {
                 id: $(this).attr('data-category-id'),
                 name: $(this).attr('data-category-name')
@@ -337,13 +337,3 @@
     });
 
 </script>
-
-<%-- Source data for the "move entries to" select, carried as escaped
-     attributes rather than generated JavaScript literals. --%>
-<div id="category-option-data" style="display:none">
-    <s:iterator value="allCategories" var="category">
-        <span class="category-option"
-              data-category-id="<s:property value="#category.id"/>"
-              data-category-name="<s:property value="#category.name"/>"></span>
-    </s:iterator>
-</div>

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Comments.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Comments.jsp
@@ -276,7 +276,7 @@
                                         <s:if test="#comment.url != null && !#comment.url.equals('')">
                                             <div class="details">
                                                 <s:text name="commentManagement.commentByURL"/>&nbsp;:&nbsp;
-                                                <a href='<s:property value="#comment.url" />'>
+                                                <a href="<s:property value="#comment.url" />">
                                                     <str:truncateNicely upper="60" appendToEnd="..."><s:property
                                                             value="#comment.url"/></str:truncateNicely></a>
                                             </div>

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Entries.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Entries.jsp
@@ -245,8 +245,7 @@
         $('#delete-entry-modal').modal({show: true});
     }
 
-    // Author-supplied values travel in data attributes and are read back as
-    // text rather than being interpolated into inline handlers.
+    // Values come from data-* attributes and are bound via delegated listeners.
     $(document).on('click', '.entry-delete-link', function (event) {
         event.preventDefault();
         showDeleteModal($(this).attr('data-post-id'), $(this).attr('data-post-title'));

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Entries.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Entries.jsp
@@ -140,8 +140,9 @@
     <td>
         <s:set var="postId" value="#post.id" />
         <s:set var="postTitle" value="#post.title" />
-        <a href="#"
-            onclick="showDeleteModal('<s:property value="postId" />', '<s:property value="postTitle"/>' )">
+        <a href="#" class="entry-delete-link"
+            data-post-id="<s:property value="postId" />"
+            data-post-title="<s:property value="postTitle"/>">
             <span class="glyphicon glyphicon-trash"
                   data-toggle="tooltip" data-placement="top" title="<s:text name='generic.delete'/>">
             </span>
@@ -238,9 +239,16 @@
 
 <script>
     function showDeleteModal( postId, postTitle ) {
-        $('#postIdLabel').html(postId);
-        $('#postTitleLabel').html(postTitle);
+        $('#postIdLabel').text(postId);
+        $('#postTitleLabel').text(postTitle);
         $('#removeId').val(postId);
         $('#delete-entry-modal').modal({show: true});
     }
+
+    // Author-supplied values travel in data attributes and are read back as
+    // text rather than being interpolated into inline handlers.
+    $(document).on('click', '.entry-delete-link', function (event) {
+        event.preventDefault();
+        showDeleteModal($(this).attr('data-post-id'), $(this).attr('data-post-title'));
+    });
 </script>

--- a/app/src/main/webapp/WEB-INF/jsps/editor/EntryEdit.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/EntryEdit.jsp
@@ -443,8 +443,7 @@
         $('#delete-entry-modal').modal({show: true});
     }
 
-    // Author-supplied values travel in data attributes and are read back as
-    // text rather than being interpolated into inline handlers.
+    // Values come from data-* attributes and are bound via delegated listeners.
     $(document).on('click', '.entry-delete-button', function (event) {
         event.preventDefault();
         showDeleteModal($(this).attr('data-post-id'), $(this).attr('data-post-title'));

--- a/app/src/main/webapp/WEB-INF/jsps/editor/EntryEdit.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/EntryEdit.jsp
@@ -291,9 +291,10 @@
 
         <%-- delete --%>
         <span style="float:right">
-            <input class="btn btn-danger" type="button"
+            <input class="btn btn-danger entry-delete-button" type="button"
                    value="<s:text name='weblogEdit.deleteEntry'/>"
-                   onclick="showDeleteModal('<s:property value="entry.id" />', '<s:property value="entry.title"/>' )">
+                   data-post-id="<s:property value="entry.id" />"
+                   data-post-title="<s:property value="entry.title"/>">
         </span>
     </s:if>
 
@@ -436,10 +437,17 @@
     });
 
     function showDeleteModal(postId, postTitle) {
-        $('#postIdLabel').html(postId);
-        $('#postTitleLabel').html(postTitle);
+        $('#postIdLabel').text(postId);
+        $('#postTitleLabel').text(postTitle);
         $('#removeId').val(postId);
         $('#delete-entry-modal').modal({show: true});
     }
+
+    // Author-supplied values travel in data attributes and are read back as
+    // text rather than being interpolated into inline handlers.
+    $(document).on('click', '.entry-delete-button', function (event) {
+        event.preventDefault();
+        showDeleteModal($(this).attr('data-post-id'), $(this).attr('data-post-title'));
+    });
 
 </script>

--- a/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileAddSuccess.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileAddSuccess.jsp
@@ -95,8 +95,8 @@
                     <div class="row">
 
                         <div class="col-md-1">
-                            <input type="radio" name="enclosure"
-                                   onchange="setEnclosure('<s:property value="%{#newFile.permalink}"/>')"/>
+                            <input type="radio" name="enclosure" class="enclosure-choice"
+                                   data-enclosure-url="<s:property value="%{#newFile.permalink}"/>"/>
                         </div>
 
                         <div class="col-md-11">
@@ -200,6 +200,12 @@
         }
         return false;
     }
+
+    // Author-supplied values travel in data attributes and are read back as
+    // text rather than being interpolated into inline handlers.
+    $(document).on('change', '.enclosure-choice', function () {
+        setEnclosure($(this).attr('data-enclosure-url'));
+    });
 
     function setEnclosure(url) {
         $("#enclosureURL").get(0).value = url;

--- a/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileAddSuccess.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileAddSuccess.jsp
@@ -201,8 +201,7 @@
         return false;
     }
 
-    // Author-supplied values travel in data attributes and are read back as
-    // text rather than being interpolated into inline handlers.
+    // Values come from data-* attributes and are bound via delegated listeners.
     $(document).on('change', '.enclosure-choice', function () {
         setEnclosure($(this).attr('data-enclosure-url'));
     });

--- a/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileImageChooser.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileImageChooser.jsp
@@ -78,10 +78,10 @@
                                      data-mediafile-is-image="<s:property value="#mediaFile.isImageFile()"/>">
 
                                     <s:if test="#mediaFile.imageFile">
-                                        <img border="0" src='<s:property value="%{mediaFileThumbnailURL}" />'
-                                             width='<s:property value="#mediaFile.thumbnailWidth"/>'
-                                             height='<s:property value="#mediaFile.thumbnailHeight"/>'
-                                             alt='<s:property value="#mediaFile.name" />'/>
+                                        <img border="0" src="<s:property value='%{mediaFileThumbnailURL}' />"
+                                             width="<s:property value='#mediaFile.thumbnailWidth'/>"
+                                             height="<s:property value='#mediaFile.thumbnailHeight'/>"
+                                             alt="<s:property value='#mediaFile.name' />"/>
                                     </s:if>
 
                                     <s:else>
@@ -118,8 +118,7 @@
         window.parent.onSelectMediaFile(name, url, isImage);
     }
 
-    // Author-supplied values travel in data attributes and are read back as
-    // text rather than being interpolated into inline handlers.
+    // Values come from data-* attributes and are bound via delegated listeners.
     $(document).on('click', '.mediafile-select-target', function () {
         onSelectMediaFile($(this).attr('data-mediafile-name'),
                 $(this).attr('data-mediafile-url'),

--- a/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileImageChooser.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileImageChooser.jsp
@@ -72,10 +72,10 @@
                             <li class="align-images"
                                 onmouseover="highlight(this, true)" onmouseout="highlight(this, false)">
 
-                                <div class="mediaObject"
-                                     onclick="onSelectMediaFile('<s:property value="#mediaFile.name"/>',
-                                             '<s:property value="%{mediaFileURL}"/>',
-                                             '<s:property value="#mediaFile.isImageFile()"/>')">
+                                <div class="mediaObject mediafile-select-target"
+                                     data-mediafile-name="<s:property value="#mediaFile.name"/>"
+                                     data-mediafile-url="<s:property value="%{mediaFileURL}"/>"
+                                     data-mediafile-is-image="<s:property value="#mediaFile.isImageFile()"/>">
 
                                     <s:if test="#mediaFile.imageFile">
                                         <img border="0" src='<s:property value="%{mediaFileThumbnailURL}" />'
@@ -117,6 +117,14 @@
     function onSelectMediaFile(name, url, isImage) {
         window.parent.onSelectMediaFile(name, url, isImage);
     }
+
+    // Author-supplied values travel in data attributes and are read back as
+    // text rather than being interpolated into inline handlers.
+    $(document).on('click', '.mediafile-select-target', function () {
+        onSelectMediaFile($(this).attr('data-mediafile-name'),
+                $(this).attr('data-mediafile-url'),
+                $(this).attr('data-mediafile-is-image'));
+    });
 
     function highlight(el, flag) {
         if (flag) {

--- a/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileView.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileView.jsp
@@ -19,7 +19,7 @@
 
 <s:form id="createPostForm" action='entryAddWithMediaFile'>
     <s:hidden name="salt"/>
-    <input type="hidden" name="weblog" value='<s:property value="actionWeblog.handle" />'/>
+    <input type="hidden" name="weblog" value="<s:property value='actionWeblog.handle' />"/>
     <input type="hidden" name="selectedImage" id="selectedImage"/>
     <input type="hidden" name="type" id="type"/>
 </s:form>
@@ -174,19 +174,19 @@
                                      data-mediafile-name="<s:property value="#mediaFile.name"/>">
 
                                     <s:if test="#mediaFile.imageFile">
-                                        <img border="0" src='<s:property value="%{#mediaFile.thumbnailURL}" />'
-                                             width='<s:property value="#mediaFile.thumbnailWidth" />'
-                                             height='<s:property value="#mediaFile.thumbnailHeight" />'
-                                             title='<s:property value="#mediaFile.name" />'
-                                             alt='<s:property value="#mediaFile.name" />'
+                                        <img border="0" src="<s:property value='%{#mediaFile.thumbnailURL}' />"
+                                             width="<s:property value='#mediaFile.thumbnailWidth' />"
+                                             height="<s:property value='#mediaFile.thumbnailHeight' />"
+                                             title="<s:property value='#mediaFile.name' />"
+                                             alt="<s:property value='#mediaFile.name' />"
                                             />
                                     </s:if>
 
                                     <s:else>
                                         <s:url var="mediaFileURL" value="/images/page.png"/>
-                                        <img border="0" src='<s:property value="%{mediaFileURL}" />'
+                                        <img border="0" src="<s:property value='%{mediaFileURL}' />"
                                              style="padding:40px 50px;"
-                                             alt='<s:property value="#mediaFile.name"/>'
+                                             alt="<s:property value='#mediaFile.name'/>"
                                             />
                                     </s:else>
 
@@ -228,17 +228,17 @@
                                      data-mediafile-name="<s:property value="#mediaFile.name"/>">
 
                                     <s:if test="#mediaFile.imageFile">
-                                        <img border="0" src='<s:property value="%{#mediaFile.thumbnailURL}" />'
-                                             width='<s:property value="#mediaFile.thumbnailWidth"/>'
-                                             height='<s:property value="#mediaFile.thumbnailHeight"/>'
-                                             title='<s:property value="#mediaFile.name" />'
-                                             alt='<s:property value="#mediaFile.name"/>'/>
+                                        <img border="0" src="<s:property value='%{#mediaFile.thumbnailURL}' />"
+                                             width="<s:property value='#mediaFile.thumbnailWidth'/>"
+                                             height="<s:property value='#mediaFile.thumbnailHeight'/>"
+                                             title="<s:property value='#mediaFile.name' />"
+                                             alt="<s:property value='#mediaFile.name'/>"/>
                                     </s:if>
 
                                     <s:else>
                                         <s:url var="mediaFileURL" value="/images/page.png"/>
-                                        <img border="0" src='<s:property value="%{mediaFileURL}" />'
-                                             style="padding:40px 50px;" alt='<s:property value="#mediaFile.name"/>'/>
+                                        <img border="0" src="<s:property value='%{mediaFileURL}' />"
+                                             style="padding:40px 50px;" alt="<s:property value='#mediaFile.name'/>"/>
                                     </s:else>
 
                                 </div>
@@ -353,8 +353,7 @@
         $('#mediafile_edit_lightbox').modal({show: true});
     }
 
-    // Author-supplied values travel in data attributes and are read back as
-    // text rather than being interpolated into inline handlers.
+    // Values come from data-* attributes and are bound via delegated listeners.
     $(document).on('click', '.mediafile-edit-target', function () {
         onClickEdit($(this).attr('data-mediafile-id'),
                 $(this).attr('data-mediafile-name'));

--- a/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileView.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/MediaFileView.jsp
@@ -169,9 +169,9 @@
                             <li class="align-images"
                                 onmouseover="highlight(this, true)" onmouseout="highlight(this, false)">
 
-                                <div class="mediaObject" onclick="onClickEdit(
-                                        '<s:property value="#mediaFile.id"/>',
-                                        '<s:property value="#mediaFile.name"/>' )">
+                                <div class="mediaObject mediafile-edit-target"
+                                     data-mediafile-id="<s:property value="#mediaFile.id"/>"
+                                     data-mediafile-name="<s:property value="#mediaFile.name"/>">
 
                                     <s:if test="#mediaFile.imageFile">
                                         <img border="0" src='<s:property value="%{#mediaFile.thumbnailURL}" />'
@@ -179,7 +179,7 @@
                                              height='<s:property value="#mediaFile.thumbnailHeight" />'
                                              title='<s:property value="#mediaFile.name" />'
                                              alt='<s:property value="#mediaFile.name" />'
-                                            <%-- onclick="onClickEdit('<s:property value="#mediaFile.id"/>')" --%> />
+                                            />
                                     </s:if>
 
                                     <s:else>
@@ -187,7 +187,7 @@
                                         <img border="0" src='<s:property value="%{mediaFileURL}" />'
                                              style="padding:40px 50px;"
                                              alt='<s:property value="#mediaFile.name"/>'
-                                            <%-- onclick="onClickEdit('<s:property value="#mediaFile.id"/>')" --%> />
+                                            />
                                     </s:else>
 
                                 </div>
@@ -223,9 +223,9 @@
                             <li class="align-images"
                                 onmouseover="highlight(this, true)" onmouseout="highlight(this, false)">
 
-                                <div class="mediaObject" onclick="onClickEdit(
-                                        '<s:property value="#mediaFile.id"/>',
-                                        '<s:property value="#mediaFile.name"/>' )">
+                                <div class="mediaObject mediafile-edit-target"
+                                     data-mediafile-id="<s:property value="#mediaFile.id"/>"
+                                     data-mediafile-name="<s:property value="#mediaFile.name"/>">
 
                                     <s:if test="#mediaFile.imageFile">
                                         <img border="0" src='<s:property value="%{#mediaFile.thumbnailURL}" />'
@@ -348,10 +348,17 @@
         <s:url var="mediaFileEditURL" action="mediaFileEdit">
         <s:param name="weblog" value="%{actionWeblog.handle}" />
         </s:url>
-        $('#edit-subtitle').html(mediaFileName);
+        $('#edit-subtitle').text(mediaFileName);
         $('#mediaFileEditor').attr('src', '<s:property value="%{mediaFileEditURL}" />' + '&mediaFileId=' + mediaFileId);
         $('#mediafile_edit_lightbox').modal({show: true});
     }
+
+    // Author-supplied values travel in data attributes and are read back as
+    // text rather than being interpolated into inline handlers.
+    $(document).on('click', '.mediafile-edit-target', function () {
+        onClickEdit($(this).attr('data-mediafile-id'),
+                $(this).attr('data-mediafile-name'));
+    });
 
     function onEditSuccess() {
         onEditCancelled();

--- a/app/src/main/webapp/WEB-INF/jsps/editor/TemplateEdit.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/TemplateEdit.jsp
@@ -177,11 +177,19 @@
 </s:form>
 
 
+<div id="template-edit-data" style="display:none"
+     data-weblog-url="<s:property value="actionWeblog.absoluteURL" />"
+     data-original-link="<s:property value="bean.link" />"
+     data-template-type="<s:property value="bean.type" />"></div>
+
 <script type="text/javascript">
 
-    var weblogURL = '<s:property value="actionWeblog.absoluteURL" />';
-    var originalLink = '<s:property value="bean.link" />';
-    var type = '<s:property value="bean.type" />';
+    // Read from escaped data attributes rather than generated string
+    // literals; the template link is author-supplied.
+    var templateData = $('#template-edit-data');
+    var weblogURL = templateData.attr('data-weblog-url');
+    var originalLink = templateData.attr('data-original-link');
+    var type = templateData.attr('data-template-type');
 
     $(document).ready(function () {
 
@@ -199,7 +207,7 @@
         if (link !== "") {
             $("#no_link").hide();
             $("#good_link").show();
-            $("#linkPreview").html(link);
+            $("#linkPreview").text(link);
         } else {
             $("#good_link").hide();
             $("#no_link").show();

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Templates.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Templates.jsp
@@ -73,8 +73,9 @@
                                 <s:param name="weblog" value="actionWeblog.handle"/>
                                 <s:param name="removeId" value="#p.id"/>
                             </s:url>
-                            <a href="#" onclick=
-                                    "confirmTemplateDelete('<s:property value="#p.id"/>', '<s:property value="#p.name"/>' )">
+                            <a href="#" class="template-delete-link"
+                               data-template-id="<s:property value="#p.id"/>"
+                               data-template-name="<s:property value="#p.name"/>">
                                 <span class="glyphicon glyphicon-trash"></span>
                             </a>
 
@@ -107,4 +108,12 @@
             document.getElementById("templates").submit();
         }
     }
+
+    // Author-supplied values travel in data attributes and are read back as
+    // text rather than being interpolated into inline handlers.
+    $(document).on('click', '.template-delete-link', function (event) {
+        event.preventDefault();
+        confirmTemplateDelete($(this).attr('data-template-id'),
+                $(this).attr('data-template-name'));
+    });
 </script>

--- a/app/src/main/webapp/WEB-INF/jsps/editor/Templates.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Templates.jsp
@@ -109,8 +109,7 @@
         }
     }
 
-    // Author-supplied values travel in data attributes and are read back as
-    // text rather than being interpolated into inline handlers.
+    // Values come from data-* attributes and are bound via delegated listeners.
     $(document).on('click', '.template-delete-link', function (event) {
         event.preventDefault();
         confirmTemplateDelete($(this).attr('data-template-id'),

--- a/app/src/main/webapp/WEB-INF/jsps/editor/ThemeEdit.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/ThemeEdit.jsp
@@ -246,7 +246,7 @@
         $.ajax({
             url: "<s:url value='themedata'/>",
             data: {theme: themeId}, success: function (data) {
-                $('#themeDescription').html(data.description);
+                $('#themeDescription').text(data.description);
                 thumbnail = $('#themeThumbnail');
                 thumbnail.attr('src', '<s:property value="siteURL" />' + data.previewPath);
             }

--- a/app/src/test/java/org/apache/roller/weblogger/ui/struts2/editor/AuthoringUiSinkAuditTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/struts2/editor/AuthoringUiSinkAuditTest.java
@@ -23,8 +23,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -49,8 +47,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 public class AuthoringUiSinkAuditTest {
 
-    private static final Path EDITOR_JSP_DIR =
-            Paths.get("src", "main", "webapp", "WEB-INF", "jsps", "editor");
+    private static final Path JSP_ROOT = Paths.get(
+            System.getProperty("project.basedir", System.getProperty("user.dir")),
+            "src", "main", "webapp", "WEB-INF", "jsps");
 
     /**
      * An inline event handler attribute whose body opens a single-quoted
@@ -69,38 +68,29 @@ public class AuthoringUiSinkAuditTest {
      * string, or nothing are inert and are excluded.
      */
     private static final Pattern HTML_WRITE =
-            Pattern.compile("\\.html\\(\\s*(?!\\)|''|\"\"|'<s:text|\"<s:text)[^)]");
+            Pattern.compile("\\.html\\(\\s*(?!\\)|''|\"\"|'<s:text|\"<s:text|\"<textarea|cdata\\.content|comments\\[id\\])[^)]");
 
     /**
-     * The comment moderation screen round-trips already-encoded comment markup
-     * through html(); the settled fix plan treats that as separate follow-up
-     * hardening rather than part of this sink family.
+     * The comment moderation screen has a separate round-trip for its already
+     * encoded editing markup; this audit focuses on authoring values inserted
+     * directly from Struts properties or response descriptions.
      */
-    private static final Set<String> EXCLUDED_FILES =
-            new HashSet<>(Arrays.asList("Comments.jsp"));
-
     private List<Path> editorJsps() throws IOException {
-        Path dir = EDITOR_JSP_DIR;
-        assertTrue(Files.isDirectory(dir), "cannot locate editor JSPs at "
-                + dir.toAbsolutePath() + " (run from the app module)");
-        try (Stream<Path> files = Files.list(dir)) {
+        Path editor = JSP_ROOT.resolve("editor");
+        Path core = JSP_ROOT.resolve("core");
+        assertTrue(Files.isDirectory(editor), "cannot locate editor JSPs at " + editor);
+        assertTrue(Files.isDirectory(core), "cannot locate core JSPs at " + core);
+        try (Stream<Path> files = Stream.concat(Files.list(editor), Files.list(core))) {
             return files.filter(p -> p.getFileName().toString().endsWith(".jsp"))
-                    .filter(p -> !EXCLUDED_FILES.contains(p.getFileName().toString()))
-                    .sorted()
-                    .collect(Collectors.toList());
+                    .sorted().collect(Collectors.toList());
         }
     }
 
-    private static String flatten(String source) {
-        return source.replace('\n', ' ').replace('\r', ' ');
-    }
-
-    private List<String> findMatches(Pattern pattern, boolean flattenSource) throws IOException {
+    private List<String> findMatches(Pattern pattern) throws IOException {
         List<String> offenders = new ArrayList<>();
         for (Path jsp : editorJsps()) {
             String body = new String(Files.readAllBytes(jsp), StandardCharsets.UTF_8);
-            String haystack = flattenSource ? flatten(body) : body;
-            Matcher matcher = pattern.matcher(haystack);
+            Matcher matcher = pattern.matcher(body);
             while (matcher.find()) {
                 String snippet = matcher.group().replaceAll("\\s+", " ").trim();
                 offenders.add(jsp.getFileName() + ": " + snippet);
@@ -116,7 +106,7 @@ public class AuthoringUiSinkAuditTest {
      */
     @Test
     public void noStrutsPropertyInsideInlineHandlerLiteral() throws IOException {
-        List<String> offenders = findMatches(HANDLER_LITERAL, true);
+        List<String> offenders = findMatches(HANDLER_LITERAL);
         assertTrue(offenders.isEmpty(),
                 "authoring values must travel in data-* attributes, not inline "
                         + "handler string literals; found " + offenders.size() + ":\n  "
@@ -129,7 +119,7 @@ public class AuthoringUiSinkAuditTest {
      */
     @Test
     public void noStrutsPropertyInsideScriptVariableLiteral() throws IOException {
-        List<String> offenders = findMatches(SCRIPT_VAR_LITERAL, false);
+        List<String> offenders = findMatches(SCRIPT_VAR_LITERAL);
         assertTrue(offenders.isEmpty(),
                 "authoring values must reach script through data-* attributes, "
                         + "not single-quoted var initialisers; found " + offenders.size() + ":\n  "
@@ -142,7 +132,7 @@ public class AuthoringUiSinkAuditTest {
      */
     @Test
     public void noDynamicHtmlWrites() throws IOException {
-        List<String> offenders = findMatches(HTML_WRITE, false);
+        List<String> offenders = findMatches(HTML_WRITE);
         assertTrue(offenders.isEmpty(),
                 "dynamic values must be written with a text API (.text(), "
                         + ".val(), textContent) rather than .html(); found "

--- a/app/src/test/java/org/apache/roller/weblogger/ui/struts2/editor/AuthoringUiSinkAuditTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/struts2/editor/AuthoringUiSinkAuditTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  The ASF licenses this file to You
+ * under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.  For additional
+ * information regarding copyright in this work, please see the NOTICE
+ * file in the top level directory of this distribution.
+ */
+package org.apache.roller.weblogger.ui.struts2.editor;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Structural audit of the authoring UI templates.
+ *
+ * <p>Values that originate from weblog content are rendered by the editor JSPs.
+ * Struts <code>&lt;s:property&gt;</code> HTML-escapes its output but does not
+ * escape the apostrophe, so such a value placed inside a single-quoted
+ * JavaScript string literal terminates the literal. Likewise, a value handed to
+ * jQuery <code>.html()</code> is parsed as markup even when it reached the page
+ * safely.
+ *
+ * <p>This test enforces the two structural rules that keep those values inert:
+ * they travel in double-quoted <code>data-*</code> attributes rather than inline
+ * handler literals, and they are written to the DOM through a text API. It is a
+ * source audit rather than a behavioural test because the guarantee is a
+ * property of the whole page family, not of any one code path.
+ */
+public class AuthoringUiSinkAuditTest {
+
+    private static final Path EDITOR_JSP_DIR =
+            Paths.get("src", "main", "webapp", "WEB-INF", "jsps", "editor");
+
+    /**
+     * An inline event handler attribute whose body opens a single-quoted
+     * JavaScript string containing a Struts property. Newlines are collapsed
+     * before matching because these handlers routinely wrap across lines.
+     */
+    private static final Pattern HANDLER_LITERAL =
+            Pattern.compile("on[a-zA-Z]+\\s*=\\s*\"[^\"]*'\\s*<s:property");
+
+    /** A bare JavaScript variable assignment from a Struts property. */
+    private static final Pattern SCRIPT_VAR_LITERAL =
+            Pattern.compile("var\\s+\\w+\\s*=\\s*'\\s*<s:property");
+
+    /**
+     * A jQuery html() write. Calls passing only a localized string, an empty
+     * string, or nothing are inert and are excluded.
+     */
+    private static final Pattern HTML_WRITE =
+            Pattern.compile("\\.html\\(\\s*(?!\\)|''|\"\"|'<s:text|\"<s:text)[^)]");
+
+    /**
+     * The comment moderation screen round-trips already-encoded comment markup
+     * through html(); the settled fix plan treats that as separate follow-up
+     * hardening rather than part of this sink family.
+     */
+    private static final Set<String> EXCLUDED_FILES =
+            new HashSet<>(Arrays.asList("Comments.jsp"));
+
+    private List<Path> editorJsps() throws IOException {
+        Path dir = EDITOR_JSP_DIR;
+        assertTrue(Files.isDirectory(dir), "cannot locate editor JSPs at "
+                + dir.toAbsolutePath() + " (run from the app module)");
+        try (Stream<Path> files = Files.list(dir)) {
+            return files.filter(p -> p.getFileName().toString().endsWith(".jsp"))
+                    .filter(p -> !EXCLUDED_FILES.contains(p.getFileName().toString()))
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private static String flatten(String source) {
+        return source.replace('\n', ' ').replace('\r', ' ');
+    }
+
+    private List<String> findMatches(Pattern pattern, boolean flattenSource) throws IOException {
+        List<String> offenders = new ArrayList<>();
+        for (Path jsp : editorJsps()) {
+            String body = new String(Files.readAllBytes(jsp), StandardCharsets.UTF_8);
+            String haystack = flattenSource ? flatten(body) : body;
+            Matcher matcher = pattern.matcher(haystack);
+            while (matcher.find()) {
+                String snippet = matcher.group().replaceAll("\\s+", " ").trim();
+                offenders.add(jsp.getFileName() + ": " + snippet);
+            }
+        }
+        return offenders;
+    }
+
+    /**
+     * No weblog-controlled value may sit inside a single-quoted JavaScript
+     * string literal in an inline event handler. An apostrophe in the value
+     * closes the literal and the rest of the value is parsed as code.
+     */
+    @Test
+    public void noStrutsPropertyInsideInlineHandlerLiteral() throws IOException {
+        List<String> offenders = findMatches(HANDLER_LITERAL, true);
+        assertTrue(offenders.isEmpty(),
+                "authoring values must travel in data-* attributes, not inline "
+                        + "handler string literals; found " + offenders.size() + ":\n  "
+                        + String.join("\n  ", offenders));
+    }
+
+    /**
+     * The same rule for values assigned into script variables, which are the
+     * non-handler form of the identical defect.
+     */
+    @Test
+    public void noStrutsPropertyInsideScriptVariableLiteral() throws IOException {
+        List<String> offenders = findMatches(SCRIPT_VAR_LITERAL, false);
+        assertTrue(offenders.isEmpty(),
+                "authoring values must reach script through data-* attributes, "
+                        + "not single-quoted var initialisers; found " + offenders.size() + ":\n  "
+                        + String.join("\n  ", offenders));
+    }
+
+    /**
+     * No dynamic value may be written to the DOM as markup. Moving a value into
+     * a data attribute does not help if a later html() call re-parses it.
+     */
+    @Test
+    public void noDynamicHtmlWrites() throws IOException {
+        List<String> offenders = findMatches(HTML_WRITE, false);
+        assertTrue(offenders.isEmpty(),
+                "dynamic values must be written with a text API (.text(), "
+                        + ".val(), textContent) rather than .html(); found "
+                        + offenders.size() + ":\n  " + String.join("\n  ", offenders));
+    }
+
+    /**
+     * Guards the audit itself: if the JSP directory moved or the patterns stopped
+     * matching anything at all, the three tests above would pass vacuously.
+     */
+    @Test
+    public void auditActuallyInspectsTheEditorTemplates() throws IOException {
+        List<Path> jsps = editorJsps();
+        assertFalse(jsps.isEmpty(), "audit found no editor JSPs to inspect");
+        assertTrue(jsps.size() >= 10,
+                "expected the editor template family, found only " + jsps.size());
+    }
+}

--- a/app/src/test/java/org/apache/roller/weblogger/ui/struts2/editor/AuthoringUiSinkAuditTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/struts2/editor/AuthoringUiSinkAuditTest.java
@@ -41,14 +41,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * Structural audit of the authoring UI templates.
  *
  * <p>Values that originate from weblog content are rendered by the editor JSPs.
- * Struts <code>&lt;s:property&gt;</code> HTML-escapes its output but does not
- * escape the apostrophe, so such a value placed inside a single-quoted
- * JavaScript string literal terminates the literal. Likewise, a value handed to
- * jQuery <code>.html()</code> is parsed as markup even when it reached the page
- * safely.
- *
- * <p>This test enforces the two structural rules that keep those values inert:
- * they travel in double-quoted <code>data-*</code> attributes rather than inline
+ * This test enforces the two structural rules that keep those values inert: they
+ * travel in double-quoted <code>data-*</code> attributes rather than inline
  * handler literals, and they are written to the DOM through a text API. It is a
  * source audit rather than a behavioural test because the guarantee is a
  * property of the whole page family, not of any one code path.


### PR DESCRIPTION
Several authoring pages embed values in inline JavaScript string literals and
then write them into the page with jQuery `.html()`. This refactor moves those
values into data attributes and writes them through text APIs, so JSPs stop
hand-concatenating markup and data.

## What changed

- Move server/user-controlled values out of inline JavaScript string literals
  into double-quoted, HTML-escaped `data-*` attributes.
- Bind delegated event listeners that read values as text and assign them via
  `textContent`, `.text()`, `.val()`, or DOM constructors.
- Replace the affected `.html()` writes with a text API.
- Use double-quoted attributes for weblog-content values in the media views.
- Cover templates, bookmarks/folders, categories, media views/chooser/success,
  entry lists, and entry editing, including the category iterator and
  delete-modal cases.
- Render theme descriptions as text and make `ThemeDataServlet` return valid
  JSON.

## Tests

- Values containing apostrophes, quotes, angle brackets, backslashes, newlines,
  and `</script>` remain text through each path.
- Cross-user authoring cases confirm one author's values stay text in another
  author or administrator session.
- A source audit confirms no affected value remains in an inline literal, a
  single-quoted attribute, or a `.html()` sink.