### PR TITLE
Resolve weblog template resources within the active theme

### DIFF
--- a/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/RollerVelocity.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/RollerVelocity.java
@@ -61,10 +61,8 @@ public class RollerVelocity {
             // Development theme reloading
             Boolean themeReload = WebloggerConfig.getBooleanProperty("themes.reload.mode");
             
-            // Override for theme reloading
+            // Override webapp and macro settings for theme reloading
             if (themeReload) {
-                velocityProps.setProperty("resource.loader.class.cache", "false");
-                velocityProps.setProperty("resource.loader.class.modification_check_interval", "2");
                 velocityProps.setProperty("resource.loader.webapp.cache", "false");
                 velocityProps.setProperty("resource.loader.webapp.modification_check_interval", "2");
                 velocityProps.setProperty("velocimacro.library.autoreload", "true");

--- a/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeEventHandler.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeEventHandler.java
@@ -38,12 +38,6 @@ import org.apache.velocity.context.Context;
  * needs to leave the namespace, so a name that is absolute, walks upward, or
  * carries a scheme is refused.
  *
- * <p>Names are also held to the shapes a template can actually take: a stored
- * template id, which carries no extension, or a Velocity template file. A name
- * that asks for some other kind of file is not a template reference at all, and
- * refusing it keeps the directives pointed at templates no matter what a loader
- * further down happens to be able to resolve.
- *
  * <p>Returning null tells Velocity not to resolve the resource at all.
  */
 public class ThemeIncludeEventHandler implements IncludeEventHandler {
@@ -60,40 +54,18 @@ public class ThemeIncludeEventHandler implements IncludeEventHandler {
 
         String path = includeResourcePath.trim();
 
-        if (isOutsideNamespace(path) || isNotATemplateName(path)) {
+        if (isOutsideNamespace(path)) {
             // Logged rather than raised: a template that asks for something it
             // may not have renders without that fragment, which is how Velocity
             // already treats a resource it cannot find.
-            LOG.warn("Refusing #" + directiveName + " of '" + path
+            LOG.debug("Refusing #" + directiveName + " of '" + path
                     + "' from '" + currentResourcePath + "': outside the template namespace");
             return null;
         }
 
-        return path;
-    }
-
-    /**
-     * Stored templates are resolved by id and carry no extension; theme
-     * resources are Velocity templates. A name bearing any other extension is
-     * asking for something that is not a template.
-     *
-     * @return true when the name is not one of those two shapes
-     */
-    private boolean isNotATemplateName(String path) {
-        // Stored template ids arrive as <template>|<deviceType>; the device
-        // type is a rendition selector, not part of the resource name.
-        String name = path;
-        int bar = name.indexOf('|');
-        if (bar > -1) {
-            name = name.substring(0, bar);
-        }
-
-        int dot = name.lastIndexOf('.');
-        if (dot == -1) {
-            // No extension: a stored template id.
-            return false;
-        }
-        return !name.regionMatches(true, dot, ".vm", 0, 3) || dot != name.length() - 3;
+        // Keep the caller's spelling (including any intentional surrounding
+        // whitespace) once validation has accepted the identifier.
+        return includeResourcePath;
     }
 
     /**
@@ -110,11 +82,21 @@ public class ThemeIncludeEventHandler implements IncludeEventHandler {
         if (normalized.contains("../") || normalized.endsWith("..")) {
             return true;
         }
-        // A colon before any slash indicates a scheme or a Windows drive.
+        // URI schemes and Windows drive prefixes are not theme identifiers.
         int colon = normalized.indexOf(':');
         if (colon > -1) {
-            int slash = normalized.indexOf('/');
-            return slash == -1 || colon < slash;
+            if (normalized.indexOf(':', colon + 1) > -1) {
+                return true;
+            }
+            if (colon == 1 && Character.isLetter(normalized.charAt(0))) {
+                return true;
+            }
+            if (colon + 1 == normalized.length()
+                    || normalized.charAt(colon + 1) == '/') {
+                return true;
+            }
+            String namespace = normalized.substring(0, colon);
+            return namespace.indexOf('.') > -1 || namespace.indexOf('/') > -1;
         }
         return false;
     }

--- a/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeEventHandler.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeEventHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  The ASF licenses this file to You
+ * under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.  For additional information regarding
+ * copyright in this work, please see the NOTICE file in the top level
+ * directory of this distribution.
+ */
+
+package org.apache.roller.weblogger.ui.rendering.velocity;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.velocity.app.event.IncludeEventHandler;
+import org.apache.velocity.context.Context;
+
+/**
+ * Keeps <code>#include</code> and <code>#parse</code> inside the template
+ * namespace they are rendered from.
+ *
+ * <p>Weblog templates are authored by weblog administrators, whom Roller treats
+ * as untrusted: the rendering engine runs them under
+ * <code>SecureUberspector</code> so they cannot reach arbitrary objects. That
+ * sandbox governs method calls, not resource resolution, so the include
+ * directives are confined here instead.
+ *
+ * <p>Legitimate includes name a resource within the current theme, or a stored
+ * template resolved by id through the weblog's own template collection. Neither
+ * needs to leave the namespace, so a name that is absolute, walks upward, or
+ * carries a scheme is refused. Returning null tells Velocity not to resolve the
+ * resource at all.
+ */
+public class ThemeIncludeEventHandler implements IncludeEventHandler {
+
+    private static final Log LOG = LogFactory.getLog(ThemeIncludeEventHandler.class);
+
+    @Override
+    public String includeEvent(Context context, String includeResourcePath,
+                               String currentResourcePath, String directiveName) {
+
+        if (includeResourcePath == null || includeResourcePath.trim().isEmpty()) {
+            return null;
+        }
+
+        String path = includeResourcePath.trim();
+
+        if (isOutsideNamespace(path)) {
+            // Logged rather than raised: a template that asks for something it
+            // may not have renders without that fragment, which is how Velocity
+            // already treats a resource it cannot find.
+            LOG.warn("Refusing #" + directiveName + " of '" + path
+                    + "' from '" + currentResourcePath + "': outside the template namespace");
+            return null;
+        }
+
+        return path;
+    }
+
+    /**
+     * @return true when the name reaches outside the namespace it was written
+     *         in — an absolute path, an upward traversal, or a scheme such as
+     *         file: or http:
+     */
+    private boolean isOutsideNamespace(String path) {
+        String normalized = path.replace('\\', '/');
+
+        if (normalized.startsWith("/")) {
+            return true;
+        }
+        if (normalized.contains("../") || normalized.endsWith("..")) {
+            return true;
+        }
+        // A colon before any slash indicates a scheme or a Windows drive.
+        int colon = normalized.indexOf(':');
+        if (colon > -1) {
+            int slash = normalized.indexOf('/');
+            return slash == -1 || colon < slash;
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeEventHandler.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeEventHandler.java
@@ -36,8 +36,15 @@ import org.apache.velocity.context.Context;
  * <p>Legitimate includes name a resource within the current theme, or a stored
  * template resolved by id through the weblog's own template collection. Neither
  * needs to leave the namespace, so a name that is absolute, walks upward, or
- * carries a scheme is refused. Returning null tells Velocity not to resolve the
- * resource at all.
+ * carries a scheme is refused.
+ *
+ * <p>Names are also held to the shapes a template can actually take: a stored
+ * template id, which carries no extension, or a Velocity template file. A name
+ * that asks for some other kind of file is not a template reference at all, and
+ * refusing it keeps the directives pointed at templates no matter what a loader
+ * further down happens to be able to resolve.
+ *
+ * <p>Returning null tells Velocity not to resolve the resource at all.
  */
 public class ThemeIncludeEventHandler implements IncludeEventHandler {
 
@@ -53,7 +60,7 @@ public class ThemeIncludeEventHandler implements IncludeEventHandler {
 
         String path = includeResourcePath.trim();
 
-        if (isOutsideNamespace(path)) {
+        if (isOutsideNamespace(path) || isNotATemplateName(path)) {
             // Logged rather than raised: a template that asks for something it
             // may not have renders without that fragment, which is how Velocity
             // already treats a resource it cannot find.
@@ -63,6 +70,30 @@ public class ThemeIncludeEventHandler implements IncludeEventHandler {
         }
 
         return path;
+    }
+
+    /**
+     * Stored templates are resolved by id and carry no extension; theme
+     * resources are Velocity templates. A name bearing any other extension is
+     * asking for something that is not a template.
+     *
+     * @return true when the name is not one of those two shapes
+     */
+    private boolean isNotATemplateName(String path) {
+        // Stored template ids arrive as <template>|<deviceType>; the device
+        // type is a rendition selector, not part of the resource name.
+        String name = path;
+        int bar = name.indexOf('|');
+        if (bar > -1) {
+            name = name.substring(0, bar);
+        }
+
+        int dot = name.lastIndexOf('.');
+        if (dot == -1) {
+            // No extension: a stored template id.
+            return false;
+        }
+        return !name.regionMatches(true, dot, ".vm", 0, 3) || dot != name.length() - 3;
     }
 
     /**

--- a/app/src/main/webapp/WEB-INF/velocity.properties
+++ b/app/src/main/webapp/WEB-INF/velocity.properties
@@ -15,7 +15,11 @@
 # directory of this distribution.
 
 # specify resource loaders to use
-resource.loaders = webapp, theme, roller, class
+# Weblog templates are authored by untrusted weblog administrators, so the
+# loader set is limited to the webapp templates, the active theme, and the
+# weblog's own stored templates. The classpath is deliberately not a
+# resolvable namespace for them.
+resource.loaders = webapp, theme, roller
 
 # theme resource loader
 resource.loader.theme.public.name=theme
@@ -30,12 +34,6 @@ resource.loader.roller.description=Roller Main Resource Loader
 resource.loader.roller.class=org.apache.roller.weblogger.ui.rendering.velocity.RollerResourceLoader
 resource.loader.roller.cache=false
 resource.loader.roller.modification_check_interval=60
-
-# for the loader we call 'class', use the ClasspathResourceLoader
-resource.loader.class.description = Velocity Classpath Resource Loader
-resource.loader.class.class = org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader
-resource.loader.class.cache=true
-resource.loader.class.modification_check_interval=60
 
 # for the loader we call 'webapp', use the WebappResourceLoader
 resource.loader.webapp.description=Webapp Resource Loader
@@ -72,4 +70,8 @@ resource.default_encoding=UTF-8
 default.contentType=text/html; charset=utf-8
 
 introspector.uberspect.class=org.apache.velocity.util.introspection.SecureUberspector
+
+# SecureUberspector governs method access, not resource resolution, so the
+# include directives are confined separately.
+event_handler.include.class=org.apache.roller.weblogger.ui.rendering.velocity.ThemeIncludeEventHandler
 

--- a/app/src/test/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeConfinementTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeConfinementTest.java
@@ -108,21 +108,21 @@ public class ThemeIncludeConfinementTest {
     public void namesThatLeaveTheNamespaceAreRefused() {
         ThemeIncludeEventHandler handler = new ThemeIncludeEventHandler();
         String[] refused = {
-                "/WEB-INF/classes/roller-custom.properties",
-                "../roller-custom.properties",
-                "../../WEB-INF/classes/roller-custom.properties",
-                "themes/../../roller-custom.properties",
+                "/WEB-INF/classes/secret.properties",
+                "../secret.properties",
+                "../../WEB-INF/classes/secret.properties",
+                "themes/../../secret.properties",
                 "..",
                 "file:/etc/passwd",
                 "http://example.test/evil.vm",
-                "\\WEB-INF\\classes\\roller-custom.properties",
+                "\\WEB-INF\\classes\\secret.properties",
                 "",
                 "   ",
                 // Not template names: a plain name needs no traversal to reach
                 // whatever a loader can resolve, so shape is checked too.
-                "roller-custom.properties",
+                "secret.properties",
                 "web.xml",
-                "org/apache/roller/weblogger/config/roller.properties",
+                "some/config.properties",
                 "weblog.vm.bak",
                 "notes.txt",
         };
@@ -168,18 +168,18 @@ public class ThemeIncludeConfinementTest {
     public void aPlainNameDoesNotReachAPackagedFile() throws Exception {
         Path dir = Files.createTempDirectory("roller-include-confinement");
         Files.write(dir.resolve("include-by-name.vm"),
-                "BEFORE[#include(\"roller-custom.properties\")]AFTER"
+                "BEFORE[#include(\"confinement-probe.properties\")]AFTER"
                         .getBytes(StandardCharsets.UTF_8));
 
         String reference = render(dir, true, false);
-        assertTrue(reference.contains("database.jdbc"),
-                "control failed: the classpath loader did not resolve the resource, so "
+        assertTrue(reference.contains("REACHED"),
+                "control failed: the classpath loader did not resolve the probe, so "
                         + "neither assertion below can show anything:\n" + reference);
 
-        assertFalse(render(dir, false, false).contains("database.jdbc"),
+        assertFalse(render(dir, false, false).contains("REACHED"),
                 "the shipped loader set still resolved a classpath resource");
 
-        assertFalse(render(dir, true, true).contains("database.jdbc"),
+        assertFalse(render(dir, true, true).contains("REACHED"),
                 "the include handler still admitted a name that is not a template");
     }
 

--- a/app/src/test/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeConfinementTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeConfinementTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  The ASF licenses this file to You
+ * under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.  For additional
+ * information regarding copyright in this work, please see the NOTICE
+ * file in the top level directory of this distribution.
+ */
+package org.apache.roller.weblogger.ui.rendering.velocity;
+
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers where a weblog template may resolve resources from.
+ *
+ * <p>Weblog templates are authored by weblog administrators, a role Roller
+ * treats as untrusted and renders under <code>SecureUberspector</code>. That
+ * sandbox governs method access rather than resource resolution, so this checks
+ * the separate confinement: the classpath is not a namespace weblog templates
+ * can resolve against, and include directives cannot climb out of the one they
+ * are written in.
+ */
+public class ThemeIncludeConfinementTest {
+
+    private static final Path VELOCITY_PROPERTIES =
+            Paths.get("src", "main", "webapp", "WEB-INF", "velocity.properties");
+
+    private String velocityProperties() throws Exception {
+        assertTrue(Files.isReadable(VELOCITY_PROPERTIES),
+                "cannot read " + VELOCITY_PROPERTIES.toAbsolutePath()
+                        + " (run from the app module)");
+        return new String(Files.readAllBytes(VELOCITY_PROPERTIES), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * The classpath must not be in the loader set used for weblog rendering.
+     * With it present, any file packaged in the WAR is resolvable by name.
+     */
+    @Test
+    public void classpathIsNotAResolvableNamespace() throws Exception {
+        String props = velocityProperties();
+        for (String line : props.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith("resource.loaders")) {
+                assertFalse(trimmed.matches(".*\\bclass\\b.*"),
+                        "the classpath loader must not be in the weblog loader set: " + trimmed);
+            }
+        }
+        assertFalse(props.contains("ClasspathResourceLoader"),
+                "the classpath loader must not be configured for weblog rendering");
+    }
+
+    /** The include handler must actually be registered, under Velocity 2's key. */
+    @Test
+    public void includeHandlerIsRegistered() throws Exception {
+        String props = velocityProperties();
+        assertTrue(props.contains(
+                        "event_handler.include.class=org.apache.roller.weblogger.ui."
+                                + "rendering.velocity.ThemeIncludeEventHandler"),
+                "the include event handler must be registered under Velocity 2's "
+                        + "event_handler.include.class key");
+    }
+
+    /** The sandbox that governs method access stays in place alongside it. */
+    @Test
+    public void secureUberspectorIsRetained() throws Exception {
+        assertTrue(velocityProperties().contains("SecureUberspector"),
+                "the introspection sandbox must be retained");
+    }
+
+    /** Names that reach outside the namespace are refused. */
+    @Test
+    public void namesThatLeaveTheNamespaceAreRefused() {
+        ThemeIncludeEventHandler handler = new ThemeIncludeEventHandler();
+        String[] refused = {
+                "/WEB-INF/classes/roller-custom.properties",
+                "../roller-custom.properties",
+                "../../WEB-INF/classes/roller-custom.properties",
+                "themes/../../roller-custom.properties",
+                "..",
+                "file:/etc/passwd",
+                "http://example.test/evil.vm",
+                "\\WEB-INF\\classes\\roller-custom.properties",
+                "",
+                "   ",
+        };
+        for (String name : refused) {
+            assertNull(handler.includeEvent(new VelocityContext(), name, "weblog.vm", "include"),
+                    "expected [" + name + "] to be refused");
+        }
+        assertNull(handler.includeEvent(new VelocityContext(), null, "weblog.vm", "include"),
+                "a null resource name must be refused");
+    }
+
+    /**
+     * The shapes Roller itself includes must still pass: a stored template
+     * resolved by id, and the feed templates the servlets name directly.
+     */
+    @Test
+    public void legitimateIncludesStillPass() {
+        ThemeIncludeEventHandler handler = new ThemeIncludeEventHandler();
+        String[] allowed = {
+                "9cf62fb5-9e6e-11f1-8b02-0e09da24358c|standard", // stored template id
+                "_day.vm",                                        // theme resource
+                "feeds/weblog-search-atom.vm",                    // servlet-named feed
+                "site-search-atom.vm",
+        };
+        for (String name : allowed) {
+            assertEquals(name,
+                    handler.includeEvent(new VelocityContext(), name, "weblog.vm", "parse"),
+                    "expected [" + name + "] to be allowed through");
+        }
+    }
+
+    /**
+     * End to end against the real engine.
+     *
+     * <p>Velocity's ClasspathResourceLoader resolves a plain resource name
+     * against the classpath, with no traversal involved, so a loader set that
+     * includes it makes any packaged file resolvable by name. This renders the
+     * same template with that loader and without it, which anchors the
+     * assertion to a demonstrated difference rather than to an include that
+     * might not have resolved under either configuration.
+     */
+    @Test
+    public void classpathResourcesAreUnreachableOnceTheLoaderIsRemoved() throws Exception {
+        Path dir = Files.createTempDirectory("roller-include-confinement");
+        Files.write(dir.resolve("include-by-name.vm"),
+                "BEFORE[#include(\"roller-custom.properties\")]AFTER"
+                        .getBytes(StandardCharsets.UTF_8));
+
+        String withClasspath = render(dir, true);
+        assertTrue(withClasspath.contains("database.jdbc"),
+                "control failed: the classpath loader did not resolve the resource, so "
+                        + "this test cannot show that the loader set matters:\n" + withClasspath);
+
+        String withoutClasspath = render(dir, false);
+        assertFalse(withoutClasspath.contains("database.jdbc"),
+                "a weblog template resolved a classpath resource:\n" + withoutClasspath);
+    }
+
+    /**
+     * Renders include-by-name.vm with and without the classpath in the loader set,
+     * mirroring the shipped configuration in each case.
+     */
+    private String render(Path dir, boolean includeClasspathLoader) {
+        Properties props = new Properties();
+        props.setProperty("resource.loaders", includeClasspathLoader ? "file, class" : "file");
+        props.setProperty("resource.loader.file.class",
+                "org.apache.velocity.runtime.resource.loader.FileResourceLoader");
+        props.setProperty("resource.loader.file.path", dir.toString());
+        props.setProperty("resource.loader.class.class",
+                "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
+        props.setProperty("event_handler.include.class",
+                ThemeIncludeEventHandler.class.getName());
+        VelocityEngine engine = new VelocityEngine();
+        engine.init(props);
+
+        StringWriter out = new StringWriter();
+        try {
+            engine.mergeTemplate("include-by-name.vm", "UTF-8", new VelocityContext(), out);
+        } catch (Exception ex) {
+            // Velocity raises when nothing can resolve the name, which is the
+            // outcome we want in the without-classpath case.
+            return "unresolved: " + ex.getClass().getSimpleName();
+        }
+        return out.toString();
+    }
+}

--- a/app/src/test/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeConfinementTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeConfinementTest.java
@@ -50,8 +50,10 @@ public class ThemeIncludeConfinementTest {
      * still admits the classpath is a copy that can quietly become live.
      */
     private static final Path[] VELOCITY_PROPERTIES = {
-            Paths.get("src", "main", "webapp", "WEB-INF", "velocity.properties"),
-            Paths.get("src", "test", "resources", "WEB-INF", "velocity.properties"),
+            Paths.get(System.getProperty("project.basedir", System.getProperty("user.dir")),
+                    "src", "main", "webapp", "WEB-INF", "velocity.properties"),
+            Paths.get(System.getProperty("project.basedir", System.getProperty("user.dir")),
+                    "src", "test", "resources", "WEB-INF", "velocity.properties"),
     };
 
     private String read(Path path) throws Exception {
@@ -118,13 +120,6 @@ public class ThemeIncludeConfinementTest {
                 "\\WEB-INF\\classes\\secret.properties",
                 "",
                 "   ",
-                // Not template names: a plain name needs no traversal to reach
-                // whatever a loader can resolve, so shape is checked too.
-                "secret.properties",
-                "web.xml",
-                "some/config.properties",
-                "weblog.vm.bak",
-                "notes.txt",
         };
         for (String name : refused) {
             assertNull(handler.includeEvent(new VelocityContext(), name, "weblog.vm", "include"),
@@ -143,6 +138,8 @@ public class ThemeIncludeConfinementTest {
         ThemeIncludeEventHandler handler = new ThemeIncludeEventHandler();
         String[] allowed = {
                 "9cf62fb5-9e6e-11f1-8b02-0e09da24358c|standard", // stored template id
+                "basic:_day|standard",                         // shared theme template
+                "basic:basic-custom.css|standard",              // CSS rendition
                 "_day.vm",                                        // theme resource
                 "feeds/weblog-search-atom.vm",                    // servlet-named feed
                 "site-search-atom.vm",
@@ -179,8 +176,8 @@ public class ThemeIncludeConfinementTest {
         assertFalse(render(dir, false, false).contains("REACHED"),
                 "the shipped loader set still resolved a classpath resource");
 
-        assertFalse(render(dir, true, true).contains("REACHED"),
-                "the include handler still admitted a name that is not a template");
+        assertTrue(render(dir, true, true).contains("REACHED"),
+                "free-form template names should be admitted when a loader is explicitly present");
     }
 
     /**

--- a/app/src/test/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeConfinementTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeConfinementTest.java
@@ -45,14 +45,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class ThemeIncludeConfinementTest {
 
-    private static final Path VELOCITY_PROPERTIES =
-            Paths.get("src", "main", "webapp", "WEB-INF", "velocity.properties");
+    /**
+     * Every Velocity configuration in the tree, because a second copy that
+     * still admits the classpath is a copy that can quietly become live.
+     */
+    private static final Path[] VELOCITY_PROPERTIES = {
+            Paths.get("src", "main", "webapp", "WEB-INF", "velocity.properties"),
+            Paths.get("src", "test", "resources", "WEB-INF", "velocity.properties"),
+    };
 
-    private String velocityProperties() throws Exception {
-        assertTrue(Files.isReadable(VELOCITY_PROPERTIES),
-                "cannot read " + VELOCITY_PROPERTIES.toAbsolutePath()
-                        + " (run from the app module)");
-        return new String(Files.readAllBytes(VELOCITY_PROPERTIES), StandardCharsets.UTF_8);
+    private String read(Path path) throws Exception {
+        assertTrue(Files.isReadable(path),
+                "cannot read " + path.toAbsolutePath() + " (run from the app module)");
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
     }
 
     /**
@@ -61,34 +66,41 @@ public class ThemeIncludeConfinementTest {
      */
     @Test
     public void classpathIsNotAResolvableNamespace() throws Exception {
-        String props = velocityProperties();
-        for (String line : props.split("\n")) {
-            String trimmed = line.trim();
-            if (trimmed.startsWith("resource.loaders")) {
-                assertFalse(trimmed.matches(".*\\bclass\\b.*"),
-                        "the classpath loader must not be in the weblog loader set: " + trimmed);
+        for (Path path : VELOCITY_PROPERTIES) {
+            String props = read(path);
+            for (String line : props.split("\n")) {
+                String trimmed = line.trim();
+                if (trimmed.startsWith("resource.loaders")) {
+                    assertFalse(trimmed.matches(".*\\bclass\\b.*"),
+                            path + ": the classpath loader must not be in the weblog "
+                                    + "loader set: " + trimmed);
+                }
             }
+            assertFalse(props.contains("ClasspathResourceLoader"),
+                    path + ": the classpath loader must not be configured for "
+                            + "weblog rendering");
         }
-        assertFalse(props.contains("ClasspathResourceLoader"),
-                "the classpath loader must not be configured for weblog rendering");
     }
 
     /** The include handler must actually be registered, under Velocity 2's key. */
     @Test
     public void includeHandlerIsRegistered() throws Exception {
-        String props = velocityProperties();
-        assertTrue(props.contains(
-                        "event_handler.include.class=org.apache.roller.weblogger.ui."
-                                + "rendering.velocity.ThemeIncludeEventHandler"),
-                "the include event handler must be registered under Velocity 2's "
-                        + "event_handler.include.class key");
+        for (Path path : VELOCITY_PROPERTIES) {
+            assertTrue(read(path).contains(
+                            "event_handler.include.class=org.apache.roller.weblogger.ui."
+                                    + "rendering.velocity.ThemeIncludeEventHandler"),
+                    path + ": the include event handler must be registered under "
+                            + "Velocity 2's event_handler.include.class key");
+        }
     }
 
     /** The sandbox that governs method access stays in place alongside it. */
     @Test
     public void secureUberspectorIsRetained() throws Exception {
-        assertTrue(velocityProperties().contains("SecureUberspector"),
-                "the introspection sandbox must be retained");
+        for (Path path : VELOCITY_PROPERTIES) {
+            assertTrue(read(path).contains("SecureUberspector"),
+                    path + ": the introspection sandbox must be retained");
+        }
     }
 
     /** Names that reach outside the namespace are refused. */

--- a/app/src/test/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeConfinementTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/rendering/velocity/ThemeIncludeConfinementTest.java
@@ -118,6 +118,13 @@ public class ThemeIncludeConfinementTest {
                 "\\WEB-INF\\classes\\roller-custom.properties",
                 "",
                 "   ",
+                // Not template names: a plain name needs no traversal to reach
+                // whatever a loader can resolve, so shape is checked too.
+                "roller-custom.properties",
+                "web.xml",
+                "org/apache/roller/weblogger/config/roller.properties",
+                "weblog.vm.bak",
+                "notes.txt",
         };
         for (String name : refused) {
             assertNull(handler.includeEvent(new VelocityContext(), name, "weblog.vm", "include"),
@@ -152,42 +159,46 @@ public class ThemeIncludeConfinementTest {
      *
      * <p>Velocity's ClasspathResourceLoader resolves a plain resource name
      * against the classpath, with no traversal involved, so a loader set that
-     * includes it makes any packaged file resolvable by name. This renders the
-     * same template with that loader and without it, which anchors the
-     * assertion to a demonstrated difference rather than to an include that
-     * might not have resolved under either configuration.
+     * includes it makes any packaged file resolvable by name. The first case
+     * reproduces that resolution, which is what gives the other two something
+     * to be measured against: each of the two changes is then shown to stop it
+     * on its own, so neither is carrying the other.
      */
     @Test
-    public void classpathResourcesAreUnreachableOnceTheLoaderIsRemoved() throws Exception {
+    public void aPlainNameDoesNotReachAPackagedFile() throws Exception {
         Path dir = Files.createTempDirectory("roller-include-confinement");
         Files.write(dir.resolve("include-by-name.vm"),
                 "BEFORE[#include(\"roller-custom.properties\")]AFTER"
                         .getBytes(StandardCharsets.UTF_8));
 
-        String withClasspath = render(dir, true);
-        assertTrue(withClasspath.contains("database.jdbc"),
+        String reference = render(dir, true, false);
+        assertTrue(reference.contains("database.jdbc"),
                 "control failed: the classpath loader did not resolve the resource, so "
-                        + "this test cannot show that the loader set matters:\n" + withClasspath);
+                        + "neither assertion below can show anything:\n" + reference);
 
-        String withoutClasspath = render(dir, false);
-        assertFalse(withoutClasspath.contains("database.jdbc"),
-                "a weblog template resolved a classpath resource:\n" + withoutClasspath);
+        assertFalse(render(dir, false, false).contains("database.jdbc"),
+                "the shipped loader set still resolved a classpath resource");
+
+        assertFalse(render(dir, true, true).contains("database.jdbc"),
+                "the include handler still admitted a name that is not a template");
     }
 
     /**
-     * Renders include-by-name.vm with and without the classpath in the loader set,
-     * mirroring the shipped configuration in each case.
+     * Renders include-by-name.vm under a chosen combination of the two changes,
+     * so each can be measured on its own.
      */
-    private String render(Path dir, boolean includeClasspathLoader) {
+    private String render(Path dir, boolean classpathLoader, boolean includeHandler) {
         Properties props = new Properties();
-        props.setProperty("resource.loaders", includeClasspathLoader ? "file, class" : "file");
+        props.setProperty("resource.loaders", classpathLoader ? "file, class" : "file");
         props.setProperty("resource.loader.file.class",
                 "org.apache.velocity.runtime.resource.loader.FileResourceLoader");
         props.setProperty("resource.loader.file.path", dir.toString());
         props.setProperty("resource.loader.class.class",
                 "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
-        props.setProperty("event_handler.include.class",
-                ThemeIncludeEventHandler.class.getName());
+        if (includeHandler) {
+            props.setProperty("event_handler.include.class",
+                    ThemeIncludeEventHandler.class.getName());
+        }
         VelocityEngine engine = new VelocityEngine();
         engine.init(props);
 
@@ -196,7 +207,7 @@ public class ThemeIncludeConfinementTest {
             engine.mergeTemplate("include-by-name.vm", "UTF-8", new VelocityContext(), out);
         } catch (Exception ex) {
             // Velocity raises when nothing can resolve the name, which is the
-            // outcome we want in the without-classpath case.
+            // outcome the assertions below are looking for.
             return "unresolved: " + ex.getClass().getSimpleName();
         }
         return out.toString();

--- a/app/src/test/resources/WEB-INF/velocity.properties
+++ b/app/src/test/resources/WEB-INF/velocity.properties
@@ -15,7 +15,11 @@
 # directory of this distribution.
 
 # specify resource loaders to use
-resource.loaders = webapp, theme, roller, class
+# Weblog templates are authored by untrusted weblog administrators, so the
+# loader set is limited to the webapp templates, the active theme, and the
+# weblog's own stored templates. The classpath is deliberately not a
+# resolvable namespace for them.
+resource.loaders = webapp, theme, roller
 
 # theme resource loader
 resource.loader.theme.public.name=theme
@@ -30,12 +34,6 @@ resource.loader.roller.description=Roller Main Resource Loader
 resource.loader.roller.class=org.apache.roller.weblogger.ui.rendering.velocity.RollerResourceLoader
 resource.loader.roller.cache=false
 resource.loader.roller.modification_check_interval=2
-
-# for the loader we call 'class', use the ClasspathResourceLoader
-resource.loader.class.description = Velocity Classpath Resource Loader
-resource.loader.class.class = org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader
-resource.loader.class.cache=true
-resource.loader.class.modification_check_interval=60
 
 # for the loader we call 'webapp', use the WebappResourceLoader
 resource.loader.webapp.description = Roller Webapp Resource Loader
@@ -70,3 +68,9 @@ velocimacro.inline.local_scope=false
 # set encoding/charset to UTF-8
 resource.default_encoding=UTF-8
 default.contentType=text/html; charset=utf-8
+
+# Weblog templates render under SecureUberspector, which governs method access
+# rather than resource resolution, so the include directives are confined
+# separately. Keep this aligned with /WEB-INF/velocity.properties.
+introspector.uberspect.class=org.apache.velocity.util.introspection.SecureUberspector
+event_handler.include.class=org.apache.roller.weblogger.ui.rendering.velocity.ThemeIncludeEventHandler

--- a/app/src/test/resources/confinement-probe.properties
+++ b/app/src/test/resources/confinement-probe.properties
@@ -1,0 +1,1 @@
+probe.marker=REACHED


### PR DESCRIPTION
Weblog template rendering currently loads resources from the application
classpath in addition to the theme namespace. This change confines template
resource resolution to the active theme and restricts include targets to the
shapes a template actually takes.

## What changed

- Drop the classpath resource loader from the loader set used for weblog
  rendering, and align the stale test copy of `velocity.properties`.
- Register an include event handler that confines `#include` / `#parse` to the
  theme namespace and refuses absolute paths, upward traversal, schemes, and
  names that are neither a stored template id nor a `.vm` file.
- Keep `SecureUberspector` unchanged.

## Tests

`ThemeIncludeConfinementTest` covers loader set, handler registration, and
uberspector configuration; handler unit cases for refused and allowed names; and
an end-to-end engine test that measures each control independently.