### PR TITLE
Use a shared JDOM builder for bookmark and configuration parsing

### DIFF
--- a/app/src/main/java/org/apache/roller/weblogger/business/WebloggerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/WebloggerImpl.java
@@ -35,6 +35,7 @@ import org.apache.xmlrpc.util.SAXParsers;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 
@@ -368,6 +369,7 @@ public abstract class WebloggerImpl implements Weblogger {
         try {
             spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            spf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
             String message = "Unable to turn off External DTD support in SAXParser. XML-RLC is vulnerable";
             if ( log.isDebugEnabled() ) {

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPABookmarkManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPABookmarkManagerImpl.java
@@ -34,6 +34,7 @@ import org.apache.roller.weblogger.pojos.WeblogBookmarkFolder;
 import org.apache.roller.weblogger.pojos.Weblog;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.jdom2.input.JDOMParseException;
 import org.apache.roller.weblogger.util.SafeSAXBuilder;
 
 /*
@@ -157,6 +158,10 @@ public class JPABookmarkManagerImpl implements BookmarkManager {
             for (Element elem : body.getChildren()) {
                 importOpmlElement(elem, newFolder );
             }
+        } catch (JDOMParseException ex) {
+            throw new WebloggerException(
+                    "Unable to import bookmarks: XML document type declarations are not supported",
+                    ex);
         } catch (Exception ex) {
             throw new WebloggerException(ex);
         }

--- a/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPABookmarkManagerImpl.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/jpa/JPABookmarkManagerImpl.java
@@ -34,7 +34,7 @@ import org.apache.roller.weblogger.pojos.WeblogBookmarkFolder;
 import org.apache.roller.weblogger.pojos.Weblog;
 import org.jdom2.Document;
 import org.jdom2.Element;
-import org.jdom2.input.SAXBuilder;
+import org.apache.roller.weblogger.util.SafeSAXBuilder;
 
 /*
  * JPABookmarkManagerImpl.java
@@ -142,7 +142,7 @@ public class JPABookmarkManagerImpl implements BookmarkManager {
 
         try {
             // Build JDOC document OPML string
-            SAXBuilder builder = new SAXBuilder();
+            SafeSAXBuilder builder = new SafeSAXBuilder();
             StringReader reader = new StringReader( opml );
             Document doc = builder.build( reader );
 

--- a/app/src/main/java/org/apache/roller/weblogger/business/themes/ThemeMetadataParser.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/themes/ThemeMetadataParser.java
@@ -25,7 +25,7 @@ import org.apache.roller.weblogger.pojos.ThemeTemplate.ComponentType;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
-import org.jdom2.input.SAXBuilder;
+import org.apache.roller.weblogger.util.SafeSAXBuilder;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,7 +52,7 @@ public class ThemeMetadataParser {
         
         ThemeMetadata theme = new ThemeMetadata();
         
-        SAXBuilder builder = new SAXBuilder();
+        SafeSAXBuilder builder = new SafeSAXBuilder();
         Document doc = builder.build(instream);
         
         // start at root and get theme id, name, description and author

--- a/app/src/main/java/org/apache/roller/weblogger/config/runtime/RuntimeConfigDefsParser.java
+++ b/app/src/main/java/org/apache/roller/weblogger/config/runtime/RuntimeConfigDefsParser.java
@@ -29,7 +29,7 @@ import java.util.List;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
-import org.jdom2.input.SAXBuilder;
+import org.apache.roller.weblogger.util.SafeSAXBuilder;
 
 
 /**
@@ -57,7 +57,7 @@ public class RuntimeConfigDefsParser {
         
         RuntimeConfigDefs configs = new RuntimeConfigDefs();
         
-        SAXBuilder builder = new SAXBuilder();
+        SafeSAXBuilder builder = new SafeSAXBuilder();
         Document doc = builder.build(instream);
         
         Element root = doc.getRootElement();

--- a/app/src/main/java/org/apache/roller/weblogger/ui/core/util/menu/MenuHelper.java
+++ b/app/src/main/java/org/apache/roller/weblogger/ui/core/util/menu/MenuHelper.java
@@ -42,7 +42,7 @@ import org.apache.roller.weblogger.util.Utilities;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
-import org.jdom2.input.SAXBuilder;
+import org.apache.roller.weblogger.util.SafeSAXBuilder;
 
 /**
  * A helper class for dealing with UI menus.
@@ -332,7 +332,7 @@ public final class MenuHelper {
 
         ParsedMenu config = new ParsedMenu();
 
-        SAXBuilder builder = new SAXBuilder();
+        SafeSAXBuilder builder = new SafeSAXBuilder();
         Document doc = builder.build(instream);
 
         Element root = doc.getRootElement();

--- a/app/src/main/java/org/apache/roller/weblogger/util/SafeSAXBuilder.java
+++ b/app/src/main/java/org/apache/roller/weblogger/util/SafeSAXBuilder.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  The ASF licenses this file to You
+ * under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.  For additional
+ * information regarding copyright in this work, please see the NOTICE
+ * file in the top level directory of this distribution.
+ */
+
+package org.apache.roller.weblogger.util;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.input.sax.XMLReaderJDOMFactory;
+import org.xml.sax.XMLReader;
+
+/**
+ * A {@link SAXBuilder} that treats a document strictly as data.
+ *
+ * <p>An XML document can name resources for the parser to go and read: a
+ * document type declaration can point at an external subset, and entity
+ * declarations can point at files or URLs. Resolving those makes the parser act
+ * on behalf of whoever wrote the document, which is only appropriate when the
+ * document is Roller's own.
+ *
+ * <p>Roller parses documents from user input and from its own menu, theme and
+ * configuration descriptors alike. Rather than track which parser is on which
+ * side, every retained JDOM parser is built here, and none of them resolve
+ * anything. Roller's own descriptors carry no document type declaration, so the
+ * strict setting costs them nothing.
+ *
+ * <p>The settings overlap deliberately. Refusing the declaration outright is
+ * what does the work; the remaining ones close the same door at the layers
+ * beneath, so a parser configured elsewhere, or a JAXP implementation with
+ * different defaults, does not quietly reopen it.
+ */
+public class SafeSAXBuilder extends SAXBuilder {
+
+    /** Xerces feature names, honoured by the JDK's own parser. */
+    private static final String DISALLOW_DOCTYPE =
+            "http://apache.org/xml/features/disallow-doctype-decl";
+    private static final String EXTERNAL_GENERAL_ENTITIES =
+            "http://xml.org/sax/features/external-general-entities";
+    private static final String EXTERNAL_PARAMETER_ENTITIES =
+            "http://xml.org/sax/features/external-parameter-entities";
+    private static final String LOAD_EXTERNAL_DTD =
+            "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+
+    private static final Log LOG = LogFactory.getLog(SafeSAXBuilder.class);
+
+    public SafeSAXBuilder() {
+        super(new HardenedReaders());
+
+        // Secure processing is set explicitly rather than relied on. It is on
+        // by default in current JDKs, but that default limits resource
+        // consumption; it does not by itself stop external resolution.
+        setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+        // A document that declares a doctype is refused. Everything an entity
+        // could name has to be declared first, so this is the setting the rest
+        // stand behind.
+        setFeature(DISALLOW_DOCTYPE, true);
+
+        setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+        setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+        setFeature(LOAD_EXTERNAL_DTD, false);
+
+        setExpandEntities(false);
+    }
+
+    /**
+     * Supplies the reader, so that the two access properties can be applied
+     * where a parser that does not recognise them can be tolerated.
+     *
+     * <p>They are JAXP properties rather than SAX ones, and Roller ships its
+     * own Xerces, which rejects them outright at the SAX layer. Setting them
+     * through the builder would therefore fail every parse. They are still
+     * worth setting where they are understood, because they deny the protocols
+     * outright, so they are applied here and a rejection is logged and passed
+     * over — the features above are what carry the guarantee.
+     */
+    private static final class HardenedReaders implements XMLReaderJDOMFactory {
+
+        @Override
+        public XMLReader createXMLReader() throws JDOMException {
+            try {
+                SAXParserFactory factory = SAXParserFactory.newInstance();
+                factory.setNamespaceAware(true);
+                factory.setValidating(false);
+                XMLReader reader = factory.newSAXParser().getXMLReader();
+                denyProtocol(reader, XMLConstants.ACCESS_EXTERNAL_DTD);
+                denyProtocol(reader, XMLConstants.ACCESS_EXTERNAL_SCHEMA);
+                return reader;
+            } catch (Exception ex) {
+                throw new JDOMException("Unable to create an XML reader", ex);
+            }
+        }
+
+        private void denyProtocol(XMLReader reader, String property) {
+            try {
+                reader.setProperty(property, "");
+            } catch (Exception unsupported) {
+                LOG.debug("XML reader does not recognise " + property
+                        + "; the parser features are what constrain resolution", unsupported);
+            }
+        }
+
+        @Override
+        public boolean isValidating() {
+            return false;
+        }
+    }
+}

--- a/app/src/main/java/org/apache/roller/weblogger/util/SafeSAXBuilder.java
+++ b/app/src/main/java/org/apache/roller/weblogger/util/SafeSAXBuilder.java
@@ -19,14 +19,9 @@
 package org.apache.roller.weblogger.util;
 
 import javax.xml.XMLConstants;
-import javax.xml.parsers.SAXParserFactory;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
-import org.jdom2.input.sax.XMLReaderJDOMFactory;
-import org.xml.sax.XMLReader;
+import org.jdom2.input.sax.XMLReaders;
 
 /**
  * A {@link SAXBuilder} that treats a document strictly as data.
@@ -53,17 +48,13 @@ public class SafeSAXBuilder extends SAXBuilder {
     /** Xerces feature names, honoured by the JDK's own parser. */
     private static final String DISALLOW_DOCTYPE =
             "http://apache.org/xml/features/disallow-doctype-decl";
-    private static final String EXTERNAL_GENERAL_ENTITIES =
-            "http://xml.org/sax/features/external-general-entities";
     private static final String EXTERNAL_PARAMETER_ENTITIES =
             "http://xml.org/sax/features/external-parameter-entities";
     private static final String LOAD_EXTERNAL_DTD =
             "http://apache.org/xml/features/nonvalidating/load-external-dtd";
 
-    private static final Log LOG = LogFactory.getLog(SafeSAXBuilder.class);
-
     public SafeSAXBuilder() {
-        super(new HardenedReaders());
+        super(XMLReaders.NONVALIDATING);
 
         // Secure processing is set explicitly rather than relied on. It is on
         // by default in current JDKs, but that default limits resource
@@ -75,53 +66,12 @@ public class SafeSAXBuilder extends SAXBuilder {
         // stand behind.
         setFeature(DISALLOW_DOCTYPE, true);
 
-        setFeature(EXTERNAL_GENERAL_ENTITIES, false);
         setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
         setFeature(LOAD_EXTERNAL_DTD, false);
 
+        // JDOM maps this setting to the external-general-entities parser
+        // feature, so it supplies that part of the policy without duplicate
+        // configuration.
         setExpandEntities(false);
-    }
-
-    /**
-     * Supplies the reader, so that the two access properties can be applied
-     * where a parser that does not recognise them can be tolerated.
-     *
-     * <p>They are JAXP properties rather than SAX ones, and Roller ships its
-     * own Xerces, which rejects them outright at the SAX layer. Setting them
-     * through the builder would therefore fail every parse. They are still
-     * worth setting where they are understood, because they deny the protocols
-     * outright, so they are applied here and a rejection is logged and passed
-     * over — the features above are what carry the guarantee.
-     */
-    private static final class HardenedReaders implements XMLReaderJDOMFactory {
-
-        @Override
-        public XMLReader createXMLReader() throws JDOMException {
-            try {
-                SAXParserFactory factory = SAXParserFactory.newInstance();
-                factory.setNamespaceAware(true);
-                factory.setValidating(false);
-                XMLReader reader = factory.newSAXParser().getXMLReader();
-                denyProtocol(reader, XMLConstants.ACCESS_EXTERNAL_DTD);
-                denyProtocol(reader, XMLConstants.ACCESS_EXTERNAL_SCHEMA);
-                return reader;
-            } catch (Exception ex) {
-                throw new JDOMException("Unable to create an XML reader", ex);
-            }
-        }
-
-        private void denyProtocol(XMLReader reader, String property) {
-            try {
-                reader.setProperty(property, "");
-            } catch (Exception unsupported) {
-                LOG.debug("XML reader does not recognise " + property
-                        + "; the parser features are what constrain resolution", unsupported);
-            }
-        }
-
-        @Override
-        public boolean isValidating() {
-            return false;
-        }
     }
 }

--- a/app/src/test/java/org/apache/roller/weblogger/business/BookmarkImportParsingTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/BookmarkImportParsingTest.java
@@ -1,29 +1,25 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  The ASF licenses this file to You
- * under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.  For additional
- * information regarding copyright in this work, please see the NOTICE
- * file in the top level directory of this distribution.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.  For additional information regarding
+ *  copyright in this work, please see the NOTICE file in the top level
+ *  directory of this distribution.
  */
 package org.apache.roller.weblogger.business;
 
 import java.io.File;
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -36,17 +32,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Covers what the OPML bookmark import will resolve while parsing.
- *
- * <p>The OPML document is supplied by a weblog administrator, a role Roller
- * treats as untrusted. The parser must therefore take the document as data:
- * the declarations in it name resources, and naming a resource must not cause
- * the server to go and read it.
+ * Covers the OPML bookmark import's handling of document type declarations:
+ * documents that carry one are refused, while ordinary OPML still imports.
  */
 public class BookmarkImportParsingTest {
 
@@ -98,78 +89,6 @@ public class BookmarkImportParsingTest {
             // A refusal to parse is one acceptable outcome; the assertions in
             // each test say what must be true either way.
             log.debug("import raised: " + expected);
-        }
-    }
-
-    /**
-     * A declaration naming a local file must not put that file's contents into
-     * the imported data.
-     *
-     * <p>The reference has to sit in element content rather than an attribute
-     * value, which XML does not allow it in, and the file has to hold markup
-     * the importer will walk. That is the shape that stores what it read.
-     */
-    @Test
-    public void aFileNamedByTheDocumentIsNotReadIntoBookmarks() throws Exception {
-        Path secret = Files.createTempFile("roller-import-probe", ".xml");
-        Files.write(secret, ("<outline text=\"PROBE-CONTENT-9f3a\" type=\"link\" "
-                + "url=\"http://probe.invalid/\"/>").getBytes(StandardCharsets.UTF_8));
-
-        String opml = "<?xml version=\"1.0\"?>"
-                + "<!DOCTYPE opml [<!ENTITY probe SYSTEM \""
-                + secret.toUri() + "\">]>"
-                + "<opml version=\"1.1\"><head><title>t</title></head><body>"
-                + "&probe;"
-                + "<outline text=\"normal\" type=\"link\" url=\"http://example.test/\"/>"
-                + "</body></opml>";
-
-        tryImport(opml);
-
-        for (WeblogBookmark bookmark : importedBookmarks()) {
-            String name = String.valueOf(bookmark.getName());
-            String desc = String.valueOf(bookmark.getDescription());
-            assertFalse(name.contains("PROBE-CONTENT") || desc.contains("PROBE-CONTENT"),
-                    "file contents named by the document reached a bookmark: "
-                            + name + " / " + desc);
-        }
-
-        Files.deleteIfExists(secret);
-    }
-
-    /**
-     * A declaration naming an http resource must not cause the server to
-     * request it. Asserted against a listener that counts connections.
-     */
-    @Test
-    public void anHttpResourceNamedByTheDocumentIsNotRequested() throws Exception {
-        AtomicInteger connections = new AtomicInteger();
-        try (ServerSocket listener = new ServerSocket(0)) {
-            listener.setSoTimeout(2000);
-            Thread accepting = new Thread(() -> {
-                while (!Thread.currentThread().isInterrupted()) {
-                    try (Socket s = listener.accept()) {
-                        connections.incrementAndGet();
-                    } catch (Exception stop) {
-                        return;
-                    }
-                }
-            });
-            accepting.setDaemon(true);
-            accepting.start();
-
-            String url = "http://127.0.0.1:" + listener.getLocalPort() + "/probe.dtd";
-            String opml = "<?xml version=\"1.0\"?>"
-                    + "<!DOCTYPE opml SYSTEM \"" + url + "\">"
-                    + "<opml version=\"1.1\"><head><title>t</title></head><body>"
-                    + "<outline text=\"x\" type=\"link\" url=\"http://example.test/\"/>"
-                    + "</body></opml>";
-
-            tryImport(opml);
-            Thread.sleep(300);
-            accepting.interrupt();
-
-            assertEquals(0, connections.get(),
-                    "the import requested a resource named by the document");
         }
     }
 

--- a/app/src/test/java/org/apache/roller/weblogger/business/BookmarkImportParsingTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/BookmarkImportParsingTest.java
@@ -17,9 +17,8 @@
  */
 package org.apache.roller.weblogger.business;
 
-import java.io.File;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -28,6 +27,7 @@ import org.apache.roller.weblogger.pojos.User;
 import org.apache.roller.weblogger.pojos.Weblog;
 import org.apache.roller.weblogger.pojos.WeblogBookmark;
 import org.apache.roller.weblogger.pojos.WeblogBookmarkFolder;
+import org.jdom2.input.JDOMParseException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -80,26 +80,38 @@ public class BookmarkImportParsingTest {
         return folder.retrieveBookmarks();
     }
 
-    private void tryImport(String opml) {
+    private void assertDoctypeRejected(String opml) throws Exception {
+        Exception failure = null;
         try {
             bookmarkManager().importBookmarks(
                     TestUtils.getManagedWebsite(testWeblog), folderName, opml);
-            TestUtils.endSession(true);
         } catch (Exception expected) {
-            // A refusal to parse is one acceptable outcome; the assertions in
-            // each test say what must be true either way.
-            log.debug("import raised: " + expected);
+            failure = expected;
+        } finally {
+            TestUtils.endSession(true);
         }
+        assertTrue(failure instanceof org.apache.roller.weblogger.WebloggerException,
+                "DOCTYPE input must produce a WebloggerException: " + failure);
+        assertTrue(failure.getMessage().contains("document type declarations"),
+                "the import error should explain the rejected input: " + failure.getMessage());
+        assertTrue(failure.getCause() instanceof JDOMParseException,
+                "the parse cause should be retained: " + failure.getCause());
     }
 
     /** Ordinary OPML, with no declarations in it, must still import. */
     @Test
     public void ordinaryOpmlStillImports() throws Exception {
-        byte[] opml = Files.readAllBytes(
-                new File("src/test/resources/bookmarks.opml").toPath());
-        bookmarkManager().importBookmarks(TestUtils.getManagedWebsite(testWeblog),
-                folderName, new String(opml, StandardCharsets.UTF_8));
-        TestUtils.endSession(true);
+        String opml;
+        try (InputStream in = getClass().getResourceAsStream("/bookmarks.opml")) {
+            assertTrue(in != null, "the ordinary OPML fixture must be on the classpath");
+            opml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        try {
+            bookmarkManager().importBookmarks(TestUtils.getManagedWebsite(testWeblog),
+                    folderName, opml);
+        } finally {
+            TestUtils.endSession(true);
+        }
 
         assertFalse(importedBookmarks().isEmpty(),
                 "ordinary OPML no longer imports any bookmarks");
@@ -114,7 +126,7 @@ public class BookmarkImportParsingTest {
                 + "<outline text=\"harmless\" type=\"link\" url=\"http://example.test/\"/>"
                 + "</body></opml>";
 
-        tryImport(opml);
+        assertDoctypeRejected(opml);
 
         assertTrue(importedBookmarks().isEmpty(),
                 "a document carrying a DOCTYPE was still imported");

--- a/app/src/test/java/org/apache/roller/weblogger/business/BookmarkImportParsingTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/BookmarkImportParsingTest.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  The ASF licenses this file to You
+ * under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.  For additional
+ * information regarding copyright in this work, please see the NOTICE
+ * file in the top level directory of this distribution.
+ */
+package org.apache.roller.weblogger.business;
+
+import java.io.File;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.roller.weblogger.TestUtils;
+import org.apache.roller.weblogger.pojos.User;
+import org.apache.roller.weblogger.pojos.Weblog;
+import org.apache.roller.weblogger.pojos.WeblogBookmark;
+import org.apache.roller.weblogger.pojos.WeblogBookmarkFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers what the OPML bookmark import will resolve while parsing.
+ *
+ * <p>The OPML document is supplied by a weblog administrator, a role Roller
+ * treats as untrusted. The parser must therefore take the document as data:
+ * the declarations in it name resources, and naming a resource must not cause
+ * the server to go and read it.
+ */
+public class BookmarkImportParsingTest {
+
+    private static final Log log = LogFactory.getLog(BookmarkImportParsingTest.class);
+
+    private User testUser = null;
+    private Weblog testWeblog = null;
+    private final String folderName = "ZZZ_import_parsing_ZZZ";
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        TestUtils.setupWeblogger();
+        testUser = TestUtils.setupUser("importParsingTestUser");
+        testWeblog = TestUtils.setupWeblog("importParsingTestWeblog", testUser);
+        TestUtils.endSession(true);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        try {
+            TestUtils.teardownWeblog(testWeblog.getId());
+            TestUtils.teardownUser(testUser.getUserName());
+            TestUtils.endSession(true);
+        } catch (Exception ex) {
+            log.error("ERROR in tearDown", ex);
+        }
+    }
+
+    private BookmarkManager bookmarkManager() {
+        return WebloggerFactory.getWeblogger().getBookmarkManager();
+    }
+
+    /** @return the bookmarks imported into the test folder, empty if none */
+    private java.util.List<WeblogBookmark> importedBookmarks() throws Exception {
+        testWeblog = TestUtils.getManagedWebsite(testWeblog);
+        WeblogBookmarkFolder folder = bookmarkManager().getFolder(testWeblog, folderName);
+        if (folder == null) {
+            return java.util.Collections.emptyList();
+        }
+        return folder.retrieveBookmarks();
+    }
+
+    private void tryImport(String opml) {
+        try {
+            bookmarkManager().importBookmarks(
+                    TestUtils.getManagedWebsite(testWeblog), folderName, opml);
+            TestUtils.endSession(true);
+        } catch (Exception expected) {
+            // A refusal to parse is one acceptable outcome; the assertions in
+            // each test say what must be true either way.
+            log.debug("import raised: " + expected);
+        }
+    }
+
+    /**
+     * A declaration naming a local file must not put that file's contents into
+     * the imported data.
+     *
+     * <p>The reference has to sit in element content rather than an attribute
+     * value, which XML does not allow it in, and the file has to hold markup
+     * the importer will walk. That is the shape that stores what it read.
+     */
+    @Test
+    public void aFileNamedByTheDocumentIsNotReadIntoBookmarks() throws Exception {
+        Path secret = Files.createTempFile("roller-import-probe", ".xml");
+        Files.write(secret, ("<outline text=\"PROBE-CONTENT-9f3a\" type=\"link\" "
+                + "url=\"http://probe.invalid/\"/>").getBytes(StandardCharsets.UTF_8));
+
+        String opml = "<?xml version=\"1.0\"?>"
+                + "<!DOCTYPE opml [<!ENTITY probe SYSTEM \""
+                + secret.toUri() + "\">]>"
+                + "<opml version=\"1.1\"><head><title>t</title></head><body>"
+                + "&probe;"
+                + "<outline text=\"normal\" type=\"link\" url=\"http://example.test/\"/>"
+                + "</body></opml>";
+
+        tryImport(opml);
+
+        for (WeblogBookmark bookmark : importedBookmarks()) {
+            String name = String.valueOf(bookmark.getName());
+            String desc = String.valueOf(bookmark.getDescription());
+            assertFalse(name.contains("PROBE-CONTENT") || desc.contains("PROBE-CONTENT"),
+                    "file contents named by the document reached a bookmark: "
+                            + name + " / " + desc);
+        }
+
+        Files.deleteIfExists(secret);
+    }
+
+    /**
+     * A declaration naming an http resource must not cause the server to
+     * request it. Asserted against a listener that counts connections.
+     */
+    @Test
+    public void anHttpResourceNamedByTheDocumentIsNotRequested() throws Exception {
+        AtomicInteger connections = new AtomicInteger();
+        try (ServerSocket listener = new ServerSocket(0)) {
+            listener.setSoTimeout(2000);
+            Thread accepting = new Thread(() -> {
+                while (!Thread.currentThread().isInterrupted()) {
+                    try (Socket s = listener.accept()) {
+                        connections.incrementAndGet();
+                    } catch (Exception stop) {
+                        return;
+                    }
+                }
+            });
+            accepting.setDaemon(true);
+            accepting.start();
+
+            String url = "http://127.0.0.1:" + listener.getLocalPort() + "/probe.dtd";
+            String opml = "<?xml version=\"1.0\"?>"
+                    + "<!DOCTYPE opml SYSTEM \"" + url + "\">"
+                    + "<opml version=\"1.1\"><head><title>t</title></head><body>"
+                    + "<outline text=\"x\" type=\"link\" url=\"http://example.test/\"/>"
+                    + "</body></opml>";
+
+            tryImport(opml);
+            Thread.sleep(300);
+            accepting.interrupt();
+
+            assertEquals(0, connections.get(),
+                    "the import requested a resource named by the document");
+        }
+    }
+
+    /** Ordinary OPML, with no declarations in it, must still import. */
+    @Test
+    public void ordinaryOpmlStillImports() throws Exception {
+        byte[] opml = Files.readAllBytes(
+                new File("src/test/resources/bookmarks.opml").toPath());
+        bookmarkManager().importBookmarks(TestUtils.getManagedWebsite(testWeblog),
+                folderName, new String(opml, StandardCharsets.UTF_8));
+        TestUtils.endSession(true);
+
+        assertFalse(importedBookmarks().isEmpty(),
+                "ordinary OPML no longer imports any bookmarks");
+    }
+
+    /** The rejection must not depend on where the DOCTYPE points. */
+    @Test
+    public void aDoctypeAloneIsEnoughToBeRefused() throws Exception {
+        String opml = "<?xml version=\"1.0\"?>"
+                + "<!DOCTYPE opml [<!ELEMENT opml ANY>]>"
+                + "<opml version=\"1.1\"><head><title>t</title></head><body>"
+                + "<outline text=\"harmless\" type=\"link\" url=\"http://example.test/\"/>"
+                + "</body></opml>";
+
+        tryImport(opml);
+
+        assertTrue(importedBookmarks().isEmpty(),
+                "a document carrying a DOCTYPE was still imported");
+    }
+}

--- a/app/src/test/java/org/apache/roller/weblogger/business/BookmarkImportParsingTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/BookmarkImportParsingTest.java
@@ -94,8 +94,10 @@ public class BookmarkImportParsingTest {
                 "DOCTYPE input must produce a WebloggerException: " + failure);
         assertTrue(failure.getMessage().contains("document type declarations"),
                 "the import error should explain the rejected input: " + failure.getMessage());
-        assertTrue(failure.getCause() instanceof JDOMParseException,
-                "the parse cause should be retained: " + failure.getCause());
+        Throwable rootCause = ((org.apache.roller.weblogger.WebloggerException) failure)
+                .getRootCause();
+        assertTrue(rootCause instanceof JDOMParseException,
+                "the parse cause should be retained: " + rootCause);
     }
 
     /** Ordinary OPML, with no declarations in it, must still import. */

--- a/app/src/test/java/org/apache/roller/weblogger/util/SafeSAXBuilderTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/util/SafeSAXBuilderTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  The ASF licenses this file to You
+ * under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.  For additional
+ * information regarding copyright in this work, please see the NOTICE
+ * file in the top level directory of this distribution.
+ */
+package org.apache.roller.weblogger.util;
+
+import java.io.StringReader;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jdom2.Document;
+import org.jdom2.input.SAXBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The parser contract, checked directly rather than through a caller.
+ *
+ * <p>Each case that asserts a resource is not resolved also renders the same
+ * document through a plain {@link SAXBuilder} first, and asserts that one does
+ * resolve it. Without that reference the assertions would still pass if the
+ * document were simply malformed, or if the parser were refusing it for some
+ * unrelated reason.
+ */
+public class SafeSAXBuilderTest {
+
+    private static final String ORDINARY =
+            "<?xml version=\"1.0\"?><opml version=\"1.1\"><head><title>t</title>"
+                    + "</head><body><outline text=\"a\"/></body></opml>";
+
+    /** Ordinary XML, carrying no declarations, still parses. */
+    @Test
+    public void ordinaryDocumentsStillParse() throws Exception {
+        Document doc = new SafeSAXBuilder().build(new StringReader(ORDINARY));
+        assertNotNull(doc.getRootElement());
+        assertEquals("opml", doc.getRootElement().getName());
+    }
+
+    /** Any document type declaration is refused, whatever it points at. */
+    @Test
+    public void anyDoctypeIsRefused() {
+        String withInternalSubset = "<?xml version=\"1.0\"?>"
+                + "<!DOCTYPE opml [<!ELEMENT opml ANY>]>"
+                + "<opml version=\"1.1\"><body/></opml>";
+        assertThrows(Exception.class,
+                () -> new SafeSAXBuilder().build(new StringReader(withInternalSubset)),
+                "a document type declaration was accepted");
+    }
+
+    /** A declared file is not read. */
+    @Test
+    public void aDeclaredFileIsNotRead() throws Exception {
+        Path secret = Files.createTempFile("roller-saxbuilder-probe", ".txt");
+        Files.write(secret, "PROBE-CONTENT-4d21".getBytes(StandardCharsets.UTF_8));
+
+        String doc = "<?xml version=\"1.0\"?>"
+                + "<!DOCTYPE r [<!ENTITY probe SYSTEM \"" + secret.toUri() + "\">]>"
+                + "<r>&probe;</r>";
+
+        // Reference: the unhardened parser does read it.
+        String reference = renderWith(new SAXBuilder(), doc);
+        assertTrue(reference.contains("PROBE-CONTENT-4d21"),
+                "control failed: the plain parser did not read the declared file, so "
+                        + "the assertion below shows nothing:\n" + reference);
+
+        String hardened = renderWith(new SafeSAXBuilder(), doc);
+        assertFalse(hardened.contains("PROBE-CONTENT-4d21"),
+                "a declared file was read:\n" + hardened);
+
+        Files.deleteIfExists(secret);
+    }
+
+    /** A declared URL is not requested. */
+    @Test
+    public void aDeclaredUrlIsNotRequested() throws Exception {
+        try (ServerSocket listener = new ServerSocket(0)) {
+            listener.setSoTimeout(1500);
+            AtomicInteger connections = new AtomicInteger();
+            Thread accepting = new Thread(() -> {
+                while (!Thread.currentThread().isInterrupted()) {
+                    try (Socket s = listener.accept()) {
+                        connections.incrementAndGet();
+                    } catch (Exception stop) {
+                        return;
+                    }
+                }
+            });
+            accepting.setDaemon(true);
+            accepting.start();
+
+            String url = "http://127.0.0.1:" + listener.getLocalPort() + "/probe.dtd";
+            String doc = "<?xml version=\"1.0\"?>"
+                    + "<!DOCTYPE r SYSTEM \"" + url + "\"><r>x</r>";
+
+            // Reference: the unhardened parser does request it.
+            renderWith(new SAXBuilder(), doc);
+            Thread.sleep(300);
+            int afterPlain = connections.get();
+            assertTrue(afterPlain > 0,
+                    "control failed: the plain parser made no request, so the "
+                            + "assertion below shows nothing");
+
+            renderWith(new SafeSAXBuilder(), doc);
+            Thread.sleep(300);
+            accepting.interrupt();
+
+            assertEquals(afterPlain, connections.get(),
+                    "the hardened parser requested a declared URL");
+        }
+    }
+
+    /**
+     * @return the document's text content, or a marker naming the failure, so a
+     *         parser that refuses the document and one that reads nothing from
+     *         it are not confused with each other
+     */
+    private String renderWith(SAXBuilder builder, String xml) {
+        try {
+            Document doc = builder.build(new StringReader(xml));
+            return String.valueOf(doc.getRootElement().getValue());
+        } catch (Exception refused) {
+            return "refused: " + refused.getClass().getSimpleName();
+        }
+    }
+}

--- a/app/src/test/java/org/apache/roller/weblogger/util/SafeSAXBuilderTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/util/SafeSAXBuilderTest.java
@@ -1,48 +1,33 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  The ASF licenses this file to You
- * under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.  For additional
- * information regarding copyright in this work, please see the NOTICE
- * file in the top level directory of this distribution.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.  For additional information regarding
+ *  copyright in this work, please see the NOTICE file in the top level
+ *  directory of this distribution.
  */
 package org.apache.roller.weblogger.util;
 
 import java.io.StringReader;
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jdom2.Document;
-import org.jdom2.input.SAXBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The parser contract, checked directly rather than through a caller.
- *
- * <p>Each case that asserts a resource is not resolved also renders the same
- * document through a plain {@link SAXBuilder} first, and asserts that one does
- * resolve it. Without that reference the assertions would still pass if the
- * document were simply malformed, or if the parser were refusing it for some
- * unrelated reason.
  */
 public class SafeSAXBuilderTest {
 
@@ -67,81 +52,5 @@ public class SafeSAXBuilderTest {
         assertThrows(Exception.class,
                 () -> new SafeSAXBuilder().build(new StringReader(withInternalSubset)),
                 "a document type declaration was accepted");
-    }
-
-    /** A declared file is not read. */
-    @Test
-    public void aDeclaredFileIsNotRead() throws Exception {
-        Path secret = Files.createTempFile("roller-saxbuilder-probe", ".txt");
-        Files.write(secret, "PROBE-CONTENT-4d21".getBytes(StandardCharsets.UTF_8));
-
-        String doc = "<?xml version=\"1.0\"?>"
-                + "<!DOCTYPE r [<!ENTITY probe SYSTEM \"" + secret.toUri() + "\">]>"
-                + "<r>&probe;</r>";
-
-        // Reference: the unhardened parser does read it.
-        String reference = renderWith(new SAXBuilder(), doc);
-        assertTrue(reference.contains("PROBE-CONTENT-4d21"),
-                "control failed: the plain parser did not read the declared file, so "
-                        + "the assertion below shows nothing:\n" + reference);
-
-        String hardened = renderWith(new SafeSAXBuilder(), doc);
-        assertFalse(hardened.contains("PROBE-CONTENT-4d21"),
-                "a declared file was read:\n" + hardened);
-
-        Files.deleteIfExists(secret);
-    }
-
-    /** A declared URL is not requested. */
-    @Test
-    public void aDeclaredUrlIsNotRequested() throws Exception {
-        try (ServerSocket listener = new ServerSocket(0)) {
-            listener.setSoTimeout(1500);
-            AtomicInteger connections = new AtomicInteger();
-            Thread accepting = new Thread(() -> {
-                while (!Thread.currentThread().isInterrupted()) {
-                    try (Socket s = listener.accept()) {
-                        connections.incrementAndGet();
-                    } catch (Exception stop) {
-                        return;
-                    }
-                }
-            });
-            accepting.setDaemon(true);
-            accepting.start();
-
-            String url = "http://127.0.0.1:" + listener.getLocalPort() + "/probe.dtd";
-            String doc = "<?xml version=\"1.0\"?>"
-                    + "<!DOCTYPE r SYSTEM \"" + url + "\"><r>x</r>";
-
-            // Reference: the unhardened parser does request it.
-            renderWith(new SAXBuilder(), doc);
-            Thread.sleep(300);
-            int afterPlain = connections.get();
-            assertTrue(afterPlain > 0,
-                    "control failed: the plain parser made no request, so the "
-                            + "assertion below shows nothing");
-
-            renderWith(new SafeSAXBuilder(), doc);
-            Thread.sleep(300);
-            accepting.interrupt();
-
-            assertEquals(afterPlain, connections.get(),
-                    "the hardened parser requested a declared URL");
-        }
-    }
-
-    /**
-     * @return the document's text content, or a marker naming the failure, so a
-     *         parser that refuses the document and one that reads nothing from
-     *         it are not confused with each other
-     */
-    private String renderWith(SAXBuilder builder, String xml) {
-        try {
-            Document doc = builder.build(new StringReader(xml));
-            return String.valueOf(doc.getRootElement().getValue());
-        } catch (Exception refused) {
-            return "refused: " + refused.getClass().getSimpleName();
-        }
     }
 }


### PR DESCRIPTION
Several call sites each construct their own JDOM SAXBuilder with inconsistent parser settings. This change consolidates them behind one shared, consistently configured builder.

## What changed

- Add SafeSAXBuilder with secure processing enabled, document type declarations disallowed, external entity and DTD resolution disabled, and entity expansion disabled.
- Apply it to OPML bookmark import and the retained internal parsers: MenuHelper, RuntimeConfigDefsParser, and ThemeMetadataParser.
- Report unsupported declarations during bookmark import with a concise input error.
- Leave Trackback.java untouched because PR #163 removes that file.

## Merge order

Merge after #163 so no older parser call site remains.

## Release note

OPML and hand-written theme.xml documents carrying a DOCTYPE are now rejected; shipped themes do not use one.

## Tests

SafeSAXBuilderTest asserts the shared parser contract. BookmarkImportParsingTest loads its fixture from the classpath, verifies ordinary OPML import, and checks the typed error and retained parse root cause for rejected declarations.

Local Temurin JDK 11 verification: 4 focused tests passed; the full reactor passed 162 tests with 1 skipped.