### PR TITLE
Fix release signing script argument handling and checksums

### DIFF
--- a/assembly-release/sign-release.sh
+++ b/assembly-release/sign-release.sh
@@ -1,31 +1,84 @@
 #!/usr/bin/env bash
+#
+# Sign and checksum the Roller release archives produced by "mvn package".
+#
+#   ROLLER_SIGNING_KEY=<keyid> ./sign-release.sh <version> [rc-suffix]
+#
+#   ./sign-release.sh 6.1.6           # final release
+#   ./sign-release.sh 6.1.6 -rc1      # release candidate
+#
+# For a release candidate the archives are renamed to carry the suffix before
+# they are signed, so the signatures match the names that are voted on.
 
-export rcstring="-rc2"
-export vstring="6.1.5"
+set -euo pipefail
 
-# for rc releases we rename the release files
-if [ rcstring != "" ]; then
-    mv target/apache-roller-${vstring}-source.tar.gz target/apache-roller-${vstring}${rcstring}-source.tar.gz
-    mv target/apache-roller-${vstring}-source.zip    target/apache-roller-${vstring}${rcstring}-source.zip
-    mv target/apache-roller-${vstring}-binary.tar.gz target/apache-roller-${vstring}${rcstring}-binary.tar.gz
-    mv target/apache-roller-${vstring}-binary.zip    target/apache-roller-${vstring}${rcstring}-binary.zip
+vstring="${1:-}"
+rcstring="${2:-}"
+
+if [ -z "$vstring" ]; then
+    echo "usage: ROLLER_SIGNING_KEY=<keyid> $0 <version> [rc-suffix]" >&2
+    echo "   eg: ROLLER_SIGNING_KEY=ABCD1234 $0 6.1.6 -rc1" >&2
+    exit 2
 fi
 
-gpg --armor --detach-sig target/apache-roller-${vstring}${rcstring}-binary.tar.gz
-gpg --armor --detach-sig target/apache-roller-${vstring}${rcstring}-binary.zip
-gpg --armor --detach-sig target/apache-roller-${vstring}${rcstring}-source.tar.gz
-gpg --armor --detach-sig target/apache-roller-${vstring}${rcstring}-source.zip
+key="${ROLLER_SIGNING_KEY:-}"
+if [ -z "$key" ]; then
+    echo "ROLLER_SIGNING_KEY is not set." >&2
+    echo "Name the signing key explicitly: older, non-compliant keys may still" >&2
+    echo "be in the keyring and gpg would otherwise pick one of them." >&2
+    exit 2
+fi
 
-gpg --print-md sha256 target/apache-roller-${vstring}${rcstring}-binary.tar.gz > \
-target/apache-roller-${vstring}${rcstring}-binary.tar.gz.sha256
+# Refuse to sign with a key that does not meet current ASF policy, which
+# requires RSA and forbids new DSA keys:
+# https://infra.apache.org/release-signing.html
+if ! keyline=$(gpg --with-colons --list-keys "$key" 2>/dev/null | grep -m1 '^pub:'); then
+    echo "no key matching '$key' in the keyring" >&2
+    exit 1
+fi
+algo=$(echo "$keyline" | cut -d: -f4)
+bits=$(echo "$keyline" | cut -d: -f3)
+if [ "$algo" != "1" ]; then
+    echo "key $key is not RSA (public key algorithm $algo); ASF policy forbids" >&2
+    echo "new DSA keys for code signing" >&2
+    exit 1
+fi
+if [ "$bits" -lt 4096 ]; then
+    echo "key $key is only $bits bits; ASF policy asks for at least 4096" >&2
+    exit 1
+fi
 
-gpg --print-md sha256 target/apache-roller-${vstring}${rcstring}-binary.zip > \
-target/apache-roller-${vstring}${rcstring}-binary.zip.sha256
+cd "$(dirname "$0")"
 
-gpg --print-md sha256 target/apache-roller-${vstring}${rcstring}-source.tar.gz > \
-target/apache-roller-${vstring}${rcstring}-source.tar.gz.sha256
+for kind in source binary; do
+    for ext in tar.gz zip; do
+        built="target/apache-roller-${vstring}-${kind}.${ext}"
+        final="target/apache-roller-${vstring}${rcstring}-${kind}.${ext}"
 
-gpg --print-md sha256 target/apache-roller-${vstring}${rcstring}-source.zip > \
-target/apache-roller-${vstring}${rcstring}-source.zip.sha256
+        if [ ! -f "$built" ] && [ ! -f "$final" ]; then
+            echo "missing $built — run 'mvn package' first" >&2
+            exit 1
+        fi
 
+        # Only rename when there is a suffix to add and the rename has not
+        # already happened. The previous version of this script tested
+        # [ rcstring != "" ], which compares the literal word against the empty
+        # string and is therefore always true, so it also "renamed" final
+        # releases onto themselves.
+        if [ -n "$rcstring" ] && [ "$built" != "$final" ] && [ -f "$built" ]; then
+            mv "$built" "$final"
+        fi
 
+        gpg --local-user "$key" --armor --detach-sig --yes "$final"
+
+        # shasum(1) format, which downloaders can feed straight back to
+        # "shasum -c". SHA-512 and SHA-256 are what current policy asks for;
+        # MD5 and SHA-1 must not be published.
+        base=$(basename "$final")
+        ( cd target && shasum -a 512 "$base" > "$base.sha512" )
+        ( cd target && shasum -a 256 "$base" > "$base.sha256" )
+    done
+done
+
+echo "Signed apache-roller-${vstring}${rcstring} with key $key:"
+ls -1 "target/apache-roller-${vstring}${rcstring}-"*


### PR DESCRIPTION
The release-candidate guard in `assembly-release/sign-release.sh` reads:

```bash
if [ rcstring != "" ]; then
```

The `$` is missing, so this compares the literal word `rcstring` against the empty string and is always true. Final releases therefore took the rename branch as well, where it degenerated into renaming each archive onto itself.

The version and RC suffix were also hardcoded to the previous release (`6.1.5` / `-rc2`), so the script had to be hand-edited before every use — and would silently sign the wrong filenames if anyone forgot.

## Changes

- Take the version and optional RC suffix as arguments, and print usage when they are missing.
- Rename only when there is a suffix to add, and skip an archive that has already been renamed, so re-running after a partial failure is not confusing.
- Require the signing key to be named via `ROLLER_SIGNING_KEY`, and refuse a key that is not RSA or is under 4096 bits. A release manager may still have older keys in their keyring, and gpg would otherwise pick one by default. See <https://infra.apache.org/release-signing.html>.
- Write checksums in `shasum(1)` format instead of `gpg --print-md`, so downloaders can verify with `shasum -c`. The `--print-md` output is space-grouped and names a `target/`-prefixed path, so it cannot be checked directly. Emit SHA-512 alongside SHA-256, per the current distribution policy.

## Verification

Guards, with real exit codes:

| invocation | result |
|---|---|
| no arguments | usage, exit 2 |
| version, no `ROLLER_SIGNING_KEY` | explains why the key must be named, exit 2 |
| key not in keyring | `no key matching ...`, exit 1 |
| DSA-1024 key | refused as not RSA, exit 1 |

Rename behaviour, against dummy archives:

- final release (no suffix) — no rename attempted, files untouched
- release candidate (`-rc1`) — archive renamed to carry the suffix before signing

The signing and checksum steps themselves need a passphrase prompt on a TTY, so they were exercised only as far as the gpg invocation.

Usage is now:

```bash
ROLLER_SIGNING_KEY=<keyid> ./sign-release.sh 6.1.6        # final
ROLLER_SIGNING_KEY=<keyid> ./sign-release.sh 6.1.6 -rc1   # candidate
```

https://claude.ai/code/session_019R1jdtwkaYEeA6L9DXEtEi