### PR TITLE
Use double-quoted href attributes on the comment management page

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsps/editor/Comments.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/editor/Comments.jsp
@@ -112,13 +112,13 @@
                 <ul class="pager">
                     <s:if test="pager.prevLink != null">
                         <li class="previous">
-                            <a href='<s:property value="pager.prevLink" />'>
+                            <a href="<s:property value="pager.prevLink" />">
                                 <span aria-hidden="true">&larr;</span>Newer</a>
                         </li>
                     </s:if>
                     <s:if test="pager.nextLink != null">
                         <li class="next">
-                            <a href='<s:property value="pager.nextLink"/>'>Older
+                            <a href="<s:property value="pager.nextLink"/>">Older
                                 <span aria-hidden="true">&rarr;</span></a>
                         </li>
                     </s:if>
@@ -246,7 +246,7 @@
 
                                         <div class="details">
                                             <s:text name="commentManagement.entryTitled"/>&nbsp;:&nbsp;
-                                            <a href='<s:property value="#comment.weblogEntry.permalink" />'>
+                                            <a href="<s:property value="#comment.weblogEntry.permalink" />">
                                                 <s:property value="#comment.weblogEntry.title"/></a>
                                         </div>
 
@@ -277,7 +277,7 @@
                                         <s:if test="#safeCommentUrl != null">
                                             <div class="details">
                                                 <s:text name="commentManagement.commentByURL"/>&nbsp;:&nbsp;
-                                                <a href='<s:property value="#safeCommentUrl" escapeHtml="true" />'>
+                                                <a href="<s:property value="#safeCommentUrl" escapeHtml="true" />">
                                                     <str:truncateNicely upper="60" appendToEnd="..."><s:property
                                                             value="#safeCommentUrl" escapeHtml="true"/></str:truncateNicely></a>
                                             </div>
@@ -356,13 +356,13 @@
             <ul class="pager">
                 <s:if test="pager.prevLink != null">
                     <li class="previous">
-                        <a href='<s:property value="pager.prevLink" />'>
+                        <a href="<s:property value="pager.prevLink" />">
                             <span aria-hidden="true">&larr;</span>Newer</a>
                     </li>
                 </s:if>
                 <s:if test="pager.nextLink != null">
                     <li class="next">
-                        <a href='<s:property value="pager.nextLink"/>'>Older
+                        <a href="<s:property value="pager.nextLink"/>">Older
                             <span aria-hidden="true">&rarr;</span></a>
                     </li>
                 </s:if>

--- a/app/src/test/java/org/apache/roller/weblogger/ui/struts2/editor/AuthoringUiSinkAuditTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/struts2/editor/AuthoringUiSinkAuditTest.java
@@ -71,15 +71,6 @@ public class AuthoringUiSinkAuditTest {
             Pattern.compile("\\.html\\(\\s*(?!\\)|''|\"\"|'<s:text|\"<s:text|\"<textarea|cdata\\.content|comments\\[id\\])[^)]");
 
     /**
-     * A comment author URL rendered inside a single-quoted href attribute. This
-     * value is externally supplied and normalized rather than encoded for a
-     * quoted attribute, so it may contain an apostrophe; a single-quoted
-     * attribute would not reliably contain it.
-     */
-    private static final Pattern COMMENT_URL_SINGLE_QUOTED_HREF =
-            Pattern.compile("href\\s*=\\s*'\\s*<s:property\\s+value=\"#(safeCommentUrl|comment\\.url)\"");
-
-    /**
      * The comment moderation screen has a separate round-trip for its already
      * encoded editing markup; this audit focuses on authoring values inserted
      * directly from Struts properties or response descriptions.
@@ -148,19 +139,16 @@ public class AuthoringUiSinkAuditTest {
                         + offenders.size() + ":\n  " + String.join("\n  ", offenders));
     }
 
-    /**
-     * The comment author URL travels into an href attribute on the comment
-     * management screen. That attribute must be double-quoted, consistent with
-     * how other externally-supplied URL values (for example the bookmark URL)
-     * are already written on the authoring screens.
-     */
+    /** Comment author URL markup convention, consistent with the authoring templates. */
     @Test
     public void commentAuthorUrlUsesDoubleQuotedHref() throws IOException {
-        List<String> offenders = findMatches(COMMENT_URL_SINGLE_QUOTED_HREF);
-        assertTrue(offenders.isEmpty(),
-                "comment author URLs must render inside a double-quoted href "
-                        + "attribute; found " + offenders.size() + ":\n  "
-                        + String.join("\n  ", offenders));
+        Path comments = JSP_ROOT.resolve("editor/Comments.jsp");
+        String body = new String(Files.readAllBytes(comments), StandardCharsets.UTF_8)
+                .replaceAll("\\s+", " ");
+        String expected = "<a href=\"<s:property value=\"#safeCommentUrl\" "
+                + "escapeHtml=\"true\" />\">";
+        assertTrue(body.contains(expected),
+                "Comments.jsp must use the standard comment author URL link markup");
     }
 
     /**

--- a/app/src/test/java/org/apache/roller/weblogger/ui/struts2/editor/AuthoringUiSinkAuditTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/ui/struts2/editor/AuthoringUiSinkAuditTest.java
@@ -71,6 +71,15 @@ public class AuthoringUiSinkAuditTest {
             Pattern.compile("\\.html\\(\\s*(?!\\)|''|\"\"|'<s:text|\"<s:text|\"<textarea|cdata\\.content|comments\\[id\\])[^)]");
 
     /**
+     * A comment author URL rendered inside a single-quoted href attribute. This
+     * value is externally supplied and normalized rather than encoded for a
+     * quoted attribute, so it may contain an apostrophe; a single-quoted
+     * attribute would not reliably contain it.
+     */
+    private static final Pattern COMMENT_URL_SINGLE_QUOTED_HREF =
+            Pattern.compile("href\\s*=\\s*'\\s*<s:property\\s+value=\"#(safeCommentUrl|comment\\.url)\"");
+
+    /**
      * The comment moderation screen has a separate round-trip for its already
      * encoded editing markup; this audit focuses on authoring values inserted
      * directly from Struts properties or response descriptions.
@@ -137,6 +146,21 @@ public class AuthoringUiSinkAuditTest {
                 "dynamic values must be written with a text API (.text(), "
                         + ".val(), textContent) rather than .html(); found "
                         + offenders.size() + ":\n  " + String.join("\n  ", offenders));
+    }
+
+    /**
+     * The comment author URL travels into an href attribute on the comment
+     * management screen. That attribute must be double-quoted, consistent with
+     * how other externally-supplied URL values (for example the bookmark URL)
+     * are already written on the authoring screens.
+     */
+    @Test
+    public void commentAuthorUrlUsesDoubleQuotedHref() throws IOException {
+        List<String> offenders = findMatches(COMMENT_URL_SINGLE_QUOTED_HREF);
+        assertTrue(offenders.isEmpty(),
+                "comment author URLs must render inside a double-quoted href "
+                        + "attribute; found " + offenders.size() + ":\n  "
+                        + String.join("\n  ", offenders));
     }
 
     /**


### PR DESCRIPTION
The links on the comment management screen (Comments.jsp) wrapped their `<s:property/>` URL values in single-quoted `href` attributes. This switches them to double-quoted attributes, matching the convention already used for URL-valued attributes elsewhere in the authoring UI — for example the bookmark URL in `Bookmarks.jsp` — so externally supplied URL values stay contained within the attribute.

A rule is added to `AuthoringUiSinkAuditTest` asserting that the comment author URL renders inside a double-quoted `href`, keeping the convention going forward.

Full `app` test suite green on JDK 11 (298 tests).