### PR TITLE
Fix blank Font Awesome icons in preset themes (CSP font-src) and document H2 VALUE workaround

### DIFF
--- a/app/src/main/webapp/themes/basic/weblog.vm
+++ b/app/src/main/webapp/themes/basic/weblog.vm
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src *; base-uri 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src *; font-src 'self'; base-uri 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'">
     <title>$model.weblog.name</title>
     #showAutodiscoveryLinks($model.weblog)
     #showAnalyticsTrackingCode($model.weblog)

--- a/app/src/main/webapp/themes/basicmobile/weblog.vm
+++ b/app/src/main/webapp/themes/basicmobile/weblog.vm
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src *; base-uri 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src *; font-src 'self'; base-uri 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'">
     <title>$model.weblog.name</title>
     #showAutodiscoveryLinks($model.weblog)
     #showAnalyticsTrackingCode($model.weblog)

--- a/app/src/main/webapp/themes/fauxcoly/weblog.vm
+++ b/app/src/main/webapp/themes/fauxcoly/weblog.vm
@@ -3,7 +3,7 @@
     <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src *; base-uri 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src *; font-src 'self'; base-uri 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'">
     #includeTemplate($model.weblog "standard_head")
     <title>$model.weblog.name: $model.weblog.tagline</title>
     #showAutodiscoveryLinks($model.weblog)

--- a/app/src/main/webapp/themes/frontpage/_header.vm
+++ b/app/src/main/webapp/themes/frontpage/_header.vm
@@ -3,7 +3,7 @@
   <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src *; base-uri 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src *; font-src 'self'; base-uri 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'">
   <title>$model.weblog.name</title>
   <link href="$url.absoluteSite/favicon.svg" rel="shortcut icon" type="image/x-icon" />
   #showAutodiscoveryLinks($model.weblog)

--- a/app/src/main/webapp/themes/gaurav/std_head.vm
+++ b/app/src/main/webapp/themes/gaurav/std_head.vm
@@ -1,5 +1,5 @@
 <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src *; base-uri 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src *; font-src 'self'; base-uri 'self'; connect-src 'self'; form-action 'self'; frame-ancestors 'none'">
 #if ($model.permalink == false)
    <meta name="Description" content="$model.weblog.about">
 #else

--- a/docs/roller-install-guide.adoc
+++ b/docs/roller-install-guide.adoc
@@ -259,6 +259,19 @@ be packaged as ojdbc14.jar, even if operating on Oracle 9 server.
 * See the server specific sections to information on where to place the
 JDBC driver jars.
 
+=== H2 database considerations
+
+H2 is not one of Roller's officially supported databases (PostgreSQL, MySQL and
+Derby are), but Roller can run against it as a generic JDBC database. If you use
+H2 2.5.250 or later, be aware that H2 now treats VALUE as a reserved word.
+Several Roller tables, such as ROLLER_PROPERTIES, have a column named VALUE, so
+Roller will fail to read them on newer H2. To work around this, append
+;NON_KEYWORDS=VALUE to your H2 JDBC connection URL, for example:
+
+----
+jdbc:h2:file:/path/to/rollerdb;NON_KEYWORDS=VALUE
+----
+
 == Deploy Roller to Tomcat
 
 Deploying Roller to the Tomcat servlet container involves creating a


### PR DESCRIPTION
Two small fixes prompted by a user testing 6.1.6 RC1.

## Preset theme CSP blocks webfonts
The Content-Security-Policy meta tag added to the preset themes in 6.1.2 sets `default-src 'none'` with no `font-src` directive, so `@font-face` webfonts fall back to `'none'` and are blocked, while the CSS still loads. In the `gaurav` theme this leaves the Font Awesome icons (the search box glyph, the "posted on" clock, etc.) blank even though the stylesheet applies.

Adding `font-src 'self'` restores same-origin webfonts. All five preset themes carry the same policy string, so they are updated together to keep it consistent; `gaurav` is the one that actually ships webfonts today (Font Awesome 3.2.1 and Bootstrap Glyphicons, served same-origin).

## H2 2.5.250 reserves VALUE
H2 2.5.250 made `VALUE` a reserved word, and several Roller tables use it as a column name (e.g. `roller_properties`), so Roller fails to read them on that H2. H2 is not an officially supported database (PostgreSQL, MySQL and Derby are), so this documents the `;NON_KEYWORDS=VALUE` JDBC URL workaround in the install guide rather than changing the schema.

https://claude.ai/code/session_015X69HHQ5XnjRkJP8ymzwFf