### PR TITLE
Track schema upgrades with a flag instead of a hardcoded version check

### DIFF
--- a/app/src/main/java/org/apache/roller/weblogger/business/startup/DatabaseInstaller.java
+++ b/app/src/main/java/org/apache/roller/weblogger/business/startup/DatabaseInstaller.java
@@ -226,37 +226,46 @@ public class DatabaseInstaller {
 
             log.info("Database is old, beginning upgrade to version "+myVersion);
 
-            boolean schemaChangesRequired = dbversion < 610;
+            // track whether any upgrade step actually ran, so the
+            // "no table changes" message stays correct without a
+            // hardcoded version constant
+            boolean schemaUpgraded = false;
 
             // iterate through each upgrade as needed
             // to add to the upgrade sequence simply add a new "if" statement
-            // for whatever version needed and then define a new method upgradeXXX()
+            // for whatever version needed, define a new method upgradeXXX(),
+            // and set schemaUpgraded = true
 
             if(dbversion < 400) {
                 upgradeTo400(con, runScripts);
                 dbversion = 400;
+                schemaUpgraded = true;
             }
             if(dbversion < 500) {
                 upgradeTo500(con, runScripts);
                 dbversion = 500;
+                schemaUpgraded = true;
             }
             if(dbversion < 510) {
                 upgradeTo510(con, runScripts);
                 dbversion = 510;
+                schemaUpgraded = true;
             }
             if(dbversion < 520) {
                 upgradeTo520(con, runScripts);
                 dbversion = 520;
+                schemaUpgraded = true;
             }
             if(dbversion < 610) {
                 upgradeTo610(con, runScripts);
                 dbversion = 610;
+                schemaUpgraded = true;
             }
 
             // make sure the database version is the exact version
             // we are upgrading too.
             updateDatabaseVersion(con, myVersion);
-            if (!schemaChangesRequired) {
+            if (!schemaUpgraded) {
                 successMessage("No table changes were required.");
             }
             successMessage("Database version updated to " + myVersion + ".");

--- a/app/src/test/java/org/apache/roller/weblogger/business/startup/DatabaseInstallerUpgradeTest.java
+++ b/app/src/test/java/org/apache/roller/weblogger/business/startup/DatabaseInstallerUpgradeTest.java
@@ -44,4 +44,36 @@ class DatabaseInstallerUpgradeTest {
         assertTrue(installer.getMessages().stream().anyMatch(m -> m.contains("No table changes were required.")));
         assertTrue(installer.getMessages().stream().anyMatch(m -> m.contains("Database version updated to " + expectedVersion + ".")));
     }
+
+    @Test
+    void schemaUpgradeSuppressesNoChangesMessage() throws Exception {
+        DatabaseProvider db = mock(DatabaseProvider.class);
+        DatabaseScriptProvider scripts = mock(DatabaseScriptProvider.class);
+        Connection con = mock(Connection.class);
+        Statement query = mock(Statement.class);
+        ResultSet rows = mock(ResultSet.class);
+        PreparedStatement update = mock(PreparedStatement.class);
+        when(db.getConnection()).thenReturn(con);
+        when(con.createStatement()).thenReturn(query);
+        when(query.executeQuery(anyString())).thenReturn(rows);
+        when(rows.next()).thenReturn(true);
+        when(rows.getString(1)).thenReturn("520");
+        when(con.prepareStatement(anyString())).thenReturn(update);
+        DatabaseInstaller installer = new DatabaseInstaller(db, scripts);
+
+        Properties props = new Properties();
+        props.load(getClass().getResourceAsStream("/roller-version.properties"));
+        int expectedVersion = DatabaseInstaller.parseVersionString(props.getProperty("ro.version", "UNKNOWN"));
+
+        // a 520 database upgrades through the 520->610 schema step; run with
+        // runScripts=false so the step does its bookkeeping without executing a
+        // migration script. Because a schema step ran, the "no table changes"
+        // message must be suppressed.
+        installer.upgradeDatabase(false);
+
+        verify(update).setString(1, String.valueOf(expectedVersion));
+        verify(update).executeUpdate();
+        assertTrue(installer.getMessages().stream().anyMatch(m -> m.contains("Database version updated to " + expectedVersion + ".")));
+        assertFalse(installer.getMessages().stream().anyMatch(m -> m.contains("No table changes were required.")));
+    }
 }


### PR DESCRIPTION
Follow-up to @mbien's review on #182.

`DatabaseInstaller.upgradeDatabase` decided whether to print "No table changes were required." from a hardcoded `boolean schemaChangesRequired = dbversion < 610;`. That constant is the last version with a migration script, so it has to be bumped by hand on every future schema change or the message goes wrong.

This adopts the pattern Michael suggested: a `schemaUpgraded` flag set inside each `if (dbversion < XXX)` upgrade block, with the message printed when `!schemaUpgraded`. The behavior is unchanged — at that point `dbversion` is already `< myVersion` and `>= 310`, so `dbversion < 610` is true exactly when one of the upgrade blocks runs — but the "did a schema step run?" answer is now derived rather than hardcoded, and the guiding comment tells the next maintainer to set the flag.

Also adds a test for the schema-change path (a 520 database upgrading through the 520→610 step, asserting the "no changes" message is suppressed) next to the existing version-only case.

Validation: JDK 11 targeted run green (`DatabaseInstallerUpgradeTest`, 2 tests, 0 failures).

https://claude.ai/code/session_015X69HHQ5XnjRkJP8ymzwFf