### PR TITLE
Fix jQuery UI 404 on authoring pages (drop webjar +1 suffix from head.jsp URL)

### DIFF
--- a/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
+++ b/app/src/main/webapp/WEB-INF/jsps/tiles/head.jsp
@@ -7,8 +7,11 @@ You can override it with your own file via WEB-INF/tiles-def.xml
 
 <script src="<s:url value='/webjars/jquery/3.7.1/jquery.min.js' />"></script>
 
-<script src="<s:url value='/webjars/jquery-ui/1.14.2+1/jquery-ui.min.js' />"></script>
-<link href="<s:url value='/webjars/jquery-ui/1.14.2+1/jquery-ui.css' />" rel="stylesheet" />
+<%-- jquery-ui webjar is 1.14.2+1 in pom.xml, but its resources are served
+     under the plus-free path: the +N is a webjar build suffix, not part of
+     the URL. Keeping the +1 here 404s and breaks the date picker/autocomplete. --%>
+<script src="<s:url value='/webjars/jquery-ui/1.14.2/jquery-ui.min.js' />"></script>
+<link href="<s:url value='/webjars/jquery-ui/1.14.2/jquery-ui.css' />" rel="stylesheet" />
 
 <script src="<s:url value='/webjars/jquery-validation/1.21.0/jquery.validate.min.js' />"></script>
 


### PR DESCRIPTION
Fixes the regression Matt Raible reported (-1) on the 6.1.6 RC2 vote thread.

The #180 dependency bump moved the `jquery-ui` webjar to `1.14.2+1`, and that literal version was written into the resource URLs in `head.jsp`. The webjar serves its resources under the plus-free path (`META-INF/resources/webjars/jquery-ui/1.14.2/`), so `/webjars/jquery-ui/1.14.2+1/jquery-ui.min.js` and `.css` both 404. That kills the entry editor's date picker and tag autocomplete (`$(...).datepicker is not a function`, `$(...).autocomplete is not a function`) and drops the jQuery UI styling.

**Fix:** point the two URLs at `1.14.2`. The pom coordinate stays `1.14.2+1` — that is the real artifact; only the resource path drops the `+N` build suffix. Verified the shipped `jquery-ui-1.14.2+1.jar` stores its files under `META-INF/resources/webjars/jquery-ui/1.14.2/`.

Regression from 6.1.5 (which was on jquery-ui 1.14.1). Targeted for 6.1.6 RC3.

https://claude.ai/code/session_015X69HHQ5XnjRkJP8ymzwFf