### PR TITLE
Make sure bootstrap tables.less .table-striped > tbody > tr:nth-of-type(2n+1) is overridden

### DIFF
--- a/app/src/main/webapp/roller-ui/styles/roller.css
+++ b/app/src/main/webapp/roller-ui/styles/roller.css
@@ -128,13 +128,13 @@ table.mm_table_actions td {
 }
 
 td.pendingentry, tr.pendingentry {
-    background: #ffcccc;
+    background: #ffcccc !important;
 }
 td.draftentry, tr.draftentry {
-    background: #ffffcc;
+    background: #ffffcc !important;
 }
 td.scheduledentry, tr.scheduledentry {
-    background: #EEEEE0;
+    background: #EEEEE0 !important;
 }
 
 .entryEditSidebarLink > a {

--- a/app/src/main/webapp/roller-ui/styles/roller.css
+++ b/app/src/main/webapp/roller-ui/styles/roller.css
@@ -272,7 +272,7 @@ body {
 
 .mediaObject {
     width:120px;
-    height:120px;
+    max-height:120px;
     margin-top: 10px;
     margin-left: 10px;
 }


### PR DESCRIPTION
On entries.rol page, bootstrap tables.less overrides odd/even table rows colouring so cannot see status of entries.